### PR TITLE
Dataplanes tags error fix

### DIFF
--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -64,7 +64,6 @@
               <span
                 class="entity-tags__label"
                 :class="`entity-tags__label--${item.label.toLowerCase()}`"
-                :style="`color: var(${tagColors[key].text}) background-color: var(${tagColors[key].fill})`"
               >
                 {{ item.label }}
               </span>
@@ -268,39 +267,7 @@ export default {
   data () {
     return {
       pageSize: 12,
-      pageNumber: 0,
-      lightText: '#fff',
-      darkText: '#000',
-      tagColors: [
-        {
-          fill: '--green-1',
-          text: this.darkText
-        },
-        {
-          fill: '--blue-2',
-          text: this.lightText
-        },
-        {
-          fill: '--blue-4',
-          text: this.lightText
-        },
-        {
-          fill: '--logo-coral',
-          text: this.darkText
-        },
-        {
-          fill: '--logo-mint',
-          text: this.darkText
-        },
-        {
-          fill: '--logo-navy',
-          text: this.lightText
-        },
-        {
-          fill: '--logo-green',
-          text: this.darkText
-        }
-      ]
+      pageNumber: 0
     }
   },
   computed: {

--- a/src/views/Entities/EntityDataplanes.vue
+++ b/src/views/Entities/EntityDataplanes.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import { humanReadableDate, dpTagCleaner } from '@/helpers'
+import { humanReadableDate } from '@/helpers'
 import DataOverview from '@/components/Skeletons/DataOverview'
 
 export default {


### PR DESCRIPTION
This was caused when the number of tags exceeded the number of colors available in an array for the tags. The tags were originally going to be different colors but instead were simplified to one color. I've removed the unused code and simplified the tag handling in `DataOverview` and this fixes the error [seen here](https://github.com/Kong/kuma/issues/618).

I admittedly overlooked this because none of my test DPs had more than 8 tags.

Now we can have more than 8 tags with no errors: [screenshot](https://share.getcloudapp.com/qGuovYoG).