### PR TITLE
added publicPath to Vue config that sets all public assets to be relative

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,7 @@
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 module.exports = {
+  publicPath: './',
   runtimeCompiler: true,
   productionSourceMap: false,
   transpileDependencies: [


### PR DESCRIPTION
This addresses a use case where a user proxies the GUI to a folder, e.g. something like `/kuma-cp/`, inside of a Kubernetes container. By default, Vue's asset path is absolute, which makes all assets 404 in this context. This would resolve that.