### PR TITLE
Added an absolute root path to the getStatus() API function

### DIFF
--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -21,7 +21,7 @@ export default class Kuma {
   }
 
   getStatus () {
-    return this.client.status()
+    return this.client.status('/')
   }
 
   /**


### PR DESCRIPTION
Prevents errors where the GUI can't find Kuma.