### PR TITLE
Chrome bugfixes

### DIFF
--- a/src/components/Global/Header.vue
+++ b/src/components/Global/Header.vue
@@ -95,7 +95,7 @@ export default {
 
   img {
     display: block;
-    width: 100%;
+    width: auto;
     height: auto;
     max-height: 46px;
   }

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -126,7 +126,7 @@ export default {
         },
         {
           metric: 'Fault Injections',
-          value: this.$store.state.totalTrafficTraceCount
+          value: this.$store.state.totalFaultInjectionCount
         }
       ]
     }

--- a/src/views/Wizard/components/StepSkeleton.vue
+++ b/src/views/Wizard/components/StepSkeleton.vue
@@ -307,22 +307,21 @@ $bp-max-width: 1219px;
     @include highlighted-step;
 
     position: relative;
-
-    &:before, &:after {
-      position: absolute;
-      content: "";
-      display: block;
-    }
+    border-right: 1px solid var(--wizard-tab-bg);
 
     // arrow
     &:after {
       --i: 20px;
+
+      position: absolute;
+      content: "";
+      display: block;
       top: 0;
       right: calc(var(--i) * -1);
       width: var(--i);
       height: 100%;
       background-color: var(--wizard-tab-bg);
-      clip-path: polygon(0 0, 100% 50%, 0 100%);
+      clip-path: polygon(100% 50%, 9% 0, 0 0, 0 100%, 10% 100%);
     }
   }
 


### PR DESCRIPTION
* [Fix] Left edge of the arrow on the Wizard step indicator did not align in Chrome. Only seems to appear on certain screen resolutions/densities, and/or different browser scales (I was able to trigger it when I scaled Chrome's content to 110%)
* [Fix] Logo scaled improperly width-wise. Chrome is finicky with SVG dimensions