### PR TITLE
Circuit Breakers

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=false
+VUE_APP_MOCK_API_ENABLED=true
 VUE_APP_KUMA_CONFIG=/dev-api-config.json

--- a/src/components/Sidebar/menu.js
+++ b/src/components/Sidebar/menu.js
@@ -37,6 +37,12 @@ export default {
           title: true
         },
         {
+          name: 'Circuit Breakers',
+          link: '/circuit-breakers',
+          title: false,
+          parent: 'policies'
+        },
+        {
           name: 'Fault Injections',
           link: '/fault-injections',
           title: false,

--- a/src/components/Utils/OnboardingCheck.vue
+++ b/src/components/Utils/OnboardingCheck.vue
@@ -55,7 +55,7 @@ export default {
       meshes: 'meshes'
     }),
     showNotice () {
-      return !this.dataplanes.length && this.onlyDefaultMesh === true
+      return !this.dataplanes && this.onlyDefaultMesh === true
     }
   },
   watch: {

--- a/src/router.js
+++ b/src/router.js
@@ -193,6 +193,15 @@ export default (store) => {
           },
           component: () => import('@/views/Policies/FaultInjections')
         },
+        // circuit breakers
+        {
+          path: 'circuit-breakers',
+          name: 'circuit-breakers',
+          meta: {
+            title: 'Circuit Breakers'
+          },
+          component: () => import('@/views/Policies/CircuitBreakers')
+        },
         // health checks
         {
           path: 'health-checks',

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -214,6 +214,25 @@ export default class Kuma {
   }
 
   /**
+   * Circuit Breakers
+   */
+
+  // get all circuit breakers
+  getAllCircuitBreakers (params) {
+    return this.client.get('/circuit-breakers', { params })
+  }
+
+  // get all circuit breakers from mesh
+  getAllCircuitBreakersFromMesh (mesh, params) {
+    return this.client.get(`/meshes/${mesh}/circuit-breakers`, { params })
+  }
+
+  // get circuit breaker details
+  getCircuitBreaker (mesh, circuitbreaker, params) {
+    return this.client.get(`/meshes/${mesh}/circuit-breakers/${circuitbreaker}`, { params })
+  }
+
+  /**
    *
    * NOTE:
    * There are no endpoints yet for fetching service information.

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -95,740 +95,740 @@ export default class Mock {
       //     }
       //   }
       // })
-      .onGet('/dataplanes').reply(200, {
-        items: [
-          {
-            mesh: 'mesh-01',
-            name: 'hello-world-foobar-002',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-00',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-10',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-20',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-30',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-40',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-50',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-60',
-            networking: {},
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'helloworld',
-            name: 'kuma-example-app-70',
-            networking: {},
-            type: 'Dataplane'
-          }
-        ]
-      })
-      .onGet('/meshes/mesh-01/dataplanes').reply(200, {
-        items: [
-          {
-            mesh: 'mesh-01',
-            name: 'hello-world-foobar-002',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.4:8000:8000',
-                  tags: {
-                    service: 'hello-world-foobar-002',
-                    tag02: 'value02',
-                    tag03: 'value03',
-                    tag04: 'value04',
-                    tag05: 'value05',
-                    tag06: 'value06',
-                    tag07: 'value07',
-                    tag08: 'value08'
-                  }
-                }
-              ]
-            },
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'mesh-01',
-            name: 'kuma-test-run-001',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.7:3000:3000',
-                  tags: {
-                    service: 'kuma-test-run-001',
-                    tag02: 'value02',
-                    tag03: 'value03',
-                    tag04: 'value04',
-                    tag05: 'value05'
-                  }
-                }
-              ],
-              outbound: [
-                {
-                  interface: ':4000',
-                  service: 'kuma-example-app'
-                }
-              ]
-            },
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'mesh-01',
-            name: 'some-really-cool-dp',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.6:6060:6060',
-                  tags: {
-                    env: 'prod',
-                    service: 'some-really-cool-dp',
-                    version: 'v8',
-                    tag02: 'value02',
-                    tag03: 'value03',
-                    tag04: 'value04'
-                  }
-                }
-              ],
-              outbound: [
-                {
-                  interface: ':5000',
-                  service: 'kuma-example-backend'
-                }
-              ]
-            },
-            type: 'Dataplane'
-          }
-        ]
-      })
-      .onGet('/meshes/default/dataplanes').reply(200, {
-        items: [
-          {
-            mesh: 'default',
-            name: 'kuma-example-app',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.4:8000:8000',
-                  tags: {
-                    service: 'kuma-example-app',
-                    tag02: 'value02',
-                    tag03: 'value03',
-                    tag04: 'value04',
-                    tag05: 'value05',
-                    tag06: 'value06',
-                    tag07: 'value07',
-                    tag08: 'value08'
-                  }
-                }
-              ]
-            },
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'default',
-            name: 'kuma-example-client',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.7:3000:3000',
-                  tags: {
-                    service: 'kuma-example-client',
-                    tag02: 'value02',
-                    tag03: 'value03',
-                    tag04: 'value04',
-                    tag05: 'value05'
-                  }
-                }
-              ],
-              outbound: [
-                {
-                  interface: ':4000',
-                  service: 'kuma-example-app'
-                }
-              ]
-            },
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'default',
-            name: 'kuma-example-web',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.6:6060:6060',
-                  tags: {
-                    env: 'prod',
-                    service: 'kuma-example-web',
-                    version: 'v8'
-                  }
-                }
-              ],
-              outbound: [
-                {
-                  interface: ':5000',
-                  service: 'kuma-example-backend'
-                }
-              ]
-            },
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'default',
-            name: 'kuma-example-backend-v1',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.3:7070:7070',
-                  tags: {
-                    env: 'prod',
-                    service: 'kuma-example-backend',
-                    version: 'v1'
-                  }
-                }
-              ]
-            },
-            type: 'Dataplane'
-          },
-          {
-            mesh: 'default',
-            name: 'kuma-example-backend-v2',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.5:7070:7070',
-                  tags: {
-                    env: 'intg',
-                    service: 'kuma-example-backend',
-                    version: 'v2'
-                  }
-                }
-              ]
-            },
-            type: 'Dataplane'
-          }
-        ]
-      })
-      .onGet('/meshes/kong-mania-12/dataplanes').reply(200, {
-        items: [
-          {
-            mesh: 'kong-mania-12',
-            name: 'hello-world-bazfoo-123',
-            networking: {
-              inbound: [
-                {
-                  interface: '172.21.0.4:8000:8000',
-                  tags: {
-                    service: 'hello-world-bazfoo-123',
-                    tag02: 'value02',
-                    tag03: 'value03',
-                    tag04: 'value04',
-                    tag05: 'value05',
-                    tag06: 'value06',
-                    tag07: 'value07',
-                    tag08: 'value08'
-                  }
-                }
-              ]
-            },
-            type: 'Dataplane'
-          }
-        ]
-      })
-      .onGet('/meshes/mesh-01/dataplanes+insights/hello-world-foobar-002').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'mesh-01',
-        name: 'hello-world-foobar-002',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-00').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-00',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-10').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-10',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-20').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-20',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-30').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-30',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-40').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-40',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-50').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-50',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
-      .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-60').reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'helloworld',
-        name: 'kuma-example-app-60',
-        dataplane: {
-          networking: {
-            address: '172.21.0.5',
-            inbound: [
-              {
-                port: 7070,
-                servicePort: 7070,
-                tags: {
-                  env: 'dev',
-                  service: 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ]
-        }
-      })
+      // .onGet('/dataplanes').reply(200, {
+      //   items: [
+      //     {
+      //       mesh: 'mesh-01',
+      //       name: 'hello-world-foobar-002',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-00',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-10',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-20',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-30',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-40',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-50',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-60',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'helloworld',
+      //       name: 'kuma-example-app-70',
+      //       networking: {},
+      //       type: 'Dataplane'
+      //     }
+      //   ]
+      // })
+      // .onGet('/meshes/mesh-01/dataplanes').reply(200, {
+      //   items: [
+      //     {
+      //       mesh: 'mesh-01',
+      //       name: 'hello-world-foobar-002',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.4:8000:8000',
+      //             tags: {
+      //               service: 'hello-world-foobar-002',
+      //               tag02: 'value02',
+      //               tag03: 'value03',
+      //               tag04: 'value04',
+      //               tag05: 'value05',
+      //               tag06: 'value06',
+      //               tag07: 'value07',
+      //               tag08: 'value08'
+      //             }
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'mesh-01',
+      //       name: 'kuma-test-run-001',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.7:3000:3000',
+      //             tags: {
+      //               service: 'kuma-test-run-001',
+      //               tag02: 'value02',
+      //               tag03: 'value03',
+      //               tag04: 'value04',
+      //               tag05: 'value05'
+      //             }
+      //           }
+      //         ],
+      //         outbound: [
+      //           {
+      //             interface: ':4000',
+      //             service: 'kuma-example-app'
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'mesh-01',
+      //       name: 'some-really-cool-dp',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.6:6060:6060',
+      //             tags: {
+      //               env: 'prod',
+      //               service: 'some-really-cool-dp',
+      //               version: 'v8',
+      //               tag02: 'value02',
+      //               tag03: 'value03',
+      //               tag04: 'value04'
+      //             }
+      //           }
+      //         ],
+      //         outbound: [
+      //           {
+      //             interface: ':5000',
+      //             service: 'kuma-example-backend'
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     }
+      //   ]
+      // })
+      // .onGet('/meshes/default/dataplanes').reply(200, {
+      //   items: [
+      //     {
+      //       mesh: 'default',
+      //       name: 'kuma-example-app',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.4:8000:8000',
+      //             tags: {
+      //               service: 'kuma-example-app',
+      //               tag02: 'value02',
+      //               tag03: 'value03',
+      //               tag04: 'value04',
+      //               tag05: 'value05',
+      //               tag06: 'value06',
+      //               tag07: 'value07',
+      //               tag08: 'value08'
+      //             }
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'default',
+      //       name: 'kuma-example-client',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.7:3000:3000',
+      //             tags: {
+      //               service: 'kuma-example-client',
+      //               tag02: 'value02',
+      //               tag03: 'value03',
+      //               tag04: 'value04',
+      //               tag05: 'value05'
+      //             }
+      //           }
+      //         ],
+      //         outbound: [
+      //           {
+      //             interface: ':4000',
+      //             service: 'kuma-example-app'
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'default',
+      //       name: 'kuma-example-web',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.6:6060:6060',
+      //             tags: {
+      //               env: 'prod',
+      //               service: 'kuma-example-web',
+      //               version: 'v8'
+      //             }
+      //           }
+      //         ],
+      //         outbound: [
+      //           {
+      //             interface: ':5000',
+      //             service: 'kuma-example-backend'
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'default',
+      //       name: 'kuma-example-backend-v1',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.3:7070:7070',
+      //             tags: {
+      //               env: 'prod',
+      //               service: 'kuma-example-backend',
+      //               version: 'v1'
+      //             }
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     },
+      //     {
+      //       mesh: 'default',
+      //       name: 'kuma-example-backend-v2',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.5:7070:7070',
+      //             tags: {
+      //               env: 'intg',
+      //               service: 'kuma-example-backend',
+      //               version: 'v2'
+      //             }
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     }
+      //   ]
+      // })
+      // .onGet('/meshes/kong-mania-12/dataplanes').reply(200, {
+      //   items: [
+      //     {
+      //       mesh: 'kong-mania-12',
+      //       name: 'hello-world-bazfoo-123',
+      //       networking: {
+      //         inbound: [
+      //           {
+      //             interface: '172.21.0.4:8000:8000',
+      //             tags: {
+      //               service: 'hello-world-bazfoo-123',
+      //               tag02: 'value02',
+      //               tag03: 'value03',
+      //               tag04: 'value04',
+      //               tag05: 'value05',
+      //               tag06: 'value06',
+      //               tag07: 'value07',
+      //               tag08: 'value08'
+      //             }
+      //           }
+      //         ]
+      //       },
+      //       type: 'Dataplane'
+      //     }
+      //   ]
+      // })
+      // .onGet('/meshes/mesh-01/dataplanes+insights/hello-world-foobar-002').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'mesh-01',
+      //   name: 'hello-world-foobar-002',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-00').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-00',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-10').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-10',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-20').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-20',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-30').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-30',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-40').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-40',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-50').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-50',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
+      // .onGet('/meshes/helloworld/dataplanes+insights/kuma-example-app-60').reply(200, {
+      //   type: 'DataplaneOverview',
+      //   mesh: 'helloworld',
+      //   name: 'kuma-example-app-60',
+      //   dataplane: {
+      //     networking: {
+      //       address: '172.21.0.5',
+      //       inbound: [
+      //         {
+      //           port: 7070,
+      //           servicePort: 7070,
+      //           tags: {
+      //             env: 'dev',
+      //             service: 'kuma-example-backend',
+      //             tag01: 'value01',
+      //             reallyLongTagLabelHere: 'a-really-long-tag-value-here'
+      //           }
+      //         }
+      //       ]
+      //     }
+      //   },
+      //   dataplaneInsight: {
+      //     subscriptions: [
+      //       {
+      //         id: '426fe0d8-f667-11e9-b081-acde48001122',
+      //         controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
+      //         connectTime: '2019-10-24T14:04:56.820350Z',
+      //         status: {
+      //           lastUpdateTime: '2019-10-24T14:04:57.832482Z',
+      //           total: {
+      //             responsesSent: '3',
+      //             responsesAcknowledged: '3'
+      //           },
+      //           cds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           eds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           lds: {
+      //             responsesSent: '1',
+      //             responsesAcknowledged: '1'
+      //           },
+      //           rds: {}
+      //         }
+      //       }
+      //     ]
+      //   }
+      // })
       .onGet('/meshes/default/traffic-traces').reply(200, {
         items: [
           {
@@ -2130,6 +2130,209 @@ export default class Mock {
             ]
           }
         ]
+      })
+      .onGet('/meshes/default/circuit-breakers').reply(200, {
+        total: 2,
+        items: [
+          {
+            type: 'CircuitBreaker',
+            mesh: 'default',
+            name: 'cb1',
+            creationTime: '2020-06-02T00:24:05.038029+07:00',
+            modificationTime: '2020-06-02T00:24:05.038029+07:00',
+            sources: [
+              {
+                match: {
+                  region: 'us',
+                  service: 'frontend'
+                }
+              }
+            ],
+            destinations: [
+              {
+                match: {
+                  service: 'backend'
+                }
+              }
+            ],
+            conf: {
+              interval: '1s',
+              baseEjectionTime: '30s',
+              maxEjectionPercent: 20,
+              detectors: {
+                totalErrors: {
+                  consecutive: 20
+                },
+                gatewayErrors: {
+                  consecutive: 10
+                },
+                localErrors: {
+                  consecutive: 7
+                },
+                standardDeviation: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  factor: 1.9
+                },
+                failure: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  threshold: 85
+                }
+              }
+            }
+          },
+          {
+            type: 'CircuitBreaker',
+            mesh: 'default',
+            name: 'cb2',
+            creationTime: '2020-06-02T00:24:48.48207+07:00',
+            modificationTime: '2020-06-02T00:24:48.48207+07:00',
+            sources: [
+              {
+                match: {
+                  region: 'eu',
+                  service: 'frontend'
+                }
+              }
+            ],
+            destinations: [
+              {
+                match: {
+                  service: 'backend'
+                }
+              }
+            ],
+            conf: {
+              interval: '30s',
+              baseEjectionTime: '130s',
+              maxEjectionPercent: 20,
+              detectors: {
+                totalErrors: {
+                  consecutive: 20
+                },
+                gatewayErrors: {
+                  consecutive: 10
+                },
+                localErrors: {
+                  consecutive: 7
+                },
+                standardDeviation: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  factor: 1.9
+                },
+                failure: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  threshold: 85
+                }
+              }
+            }
+          }
+        ],
+        next: null
+      })
+      .onGet('/meshes/alpha-tango-mesh/circuit-breakers').reply(200, {
+        total: 0,
+        items: [],
+        next: null
+      })
+      .onGet('/meshes/default/circuit-breakers/cb1').reply(200, {
+        type: 'CircuitBreaker',
+        mesh: 'default',
+        name: 'cb1',
+        creationTime: '2020-06-02T00:24:05.038029+07:00',
+        modificationTime: '2020-06-02T00:24:05.038029+07:00',
+        sources: [
+          {
+            match: {
+              region: 'us',
+              service: 'frontend'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        conf: {
+          interval: '1s',
+          baseEjectionTime: '30s',
+          maxEjectionPercent: 20,
+          detectors: {
+            totalErrors: {
+              consecutive: 20
+            },
+            gatewayErrors: {
+              consecutive: 10
+            },
+            localErrors: {
+              consecutive: 7
+            },
+            standardDeviation: {
+              requestVolume: 10,
+              minimumHosts: 5,
+              factor: 1.9
+            },
+            failure: {
+              requestVolume: 10,
+              minimumHosts: 5,
+              threshold: 85
+            }
+          }
+        }
+      })
+      .onGet('/meshes/default/circuit-breakers/cb2').reply(200, {
+        type: 'CircuitBreaker',
+        mesh: 'default',
+        name: 'cb2',
+        creationTime: '2020-06-02T00:24:05.038029+07:00',
+        modificationTime: '2020-06-02T00:24:05.038029+07:00',
+        sources: [
+          {
+            match: {
+              region: 'us',
+              service: 'frontend'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        conf: {
+          interval: '1s',
+          baseEjectionTime: '30s',
+          maxEjectionPercent: 20,
+          detectors: {
+            totalErrors: {
+              consecutive: 20
+            },
+            gatewayErrors: {
+              consecutive: 10
+            },
+            localErrors: {
+              consecutive: 7
+            },
+            standardDeviation: {
+              requestVolume: 10,
+              minimumHosts: 5,
+              factor: 1.9
+            },
+            failure: {
+              requestVolume: 10,
+              minimumHosts: 5,
+              threshold: 85
+            }
+          }
+        }
       })
       .onAny().passThrough()
   }

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -2233,6 +2233,108 @@ export default class Mock {
         ],
         next: null
       })
+      .onGet('/circuit-breakers').reply(200, {
+        total: 2,
+        items: [
+          {
+            type: 'CircuitBreaker',
+            mesh: 'default',
+            name: 'cb1',
+            creationTime: '2020-06-02T00:24:05.038029+07:00',
+            modificationTime: '2020-06-02T00:24:05.038029+07:00',
+            sources: [
+              {
+                match: {
+                  region: 'us',
+                  service: 'frontend'
+                }
+              }
+            ],
+            destinations: [
+              {
+                match: {
+                  service: 'backend'
+                }
+              }
+            ],
+            conf: {
+              interval: '1s',
+              baseEjectionTime: '30s',
+              maxEjectionPercent: 20,
+              detectors: {
+                totalErrors: {
+                  consecutive: 20
+                },
+                gatewayErrors: {
+                  consecutive: 10
+                },
+                localErrors: {
+                  consecutive: 7
+                },
+                standardDeviation: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  factor: 1.9
+                },
+                failure: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  threshold: 85
+                }
+              }
+            }
+          },
+          {
+            type: 'CircuitBreaker',
+            mesh: 'default',
+            name: 'cb2',
+            creationTime: '2020-06-02T00:24:48.48207+07:00',
+            modificationTime: '2020-06-02T00:24:48.48207+07:00',
+            sources: [
+              {
+                match: {
+                  region: 'eu',
+                  service: 'frontend'
+                }
+              }
+            ],
+            destinations: [
+              {
+                match: {
+                  service: 'backend'
+                }
+              }
+            ],
+            conf: {
+              interval: '30s',
+              baseEjectionTime: '130s',
+              maxEjectionPercent: 20,
+              detectors: {
+                totalErrors: {
+                  consecutive: 20
+                },
+                gatewayErrors: {
+                  consecutive: 10
+                },
+                localErrors: {
+                  consecutive: 7
+                },
+                standardDeviation: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  factor: 1.9
+                },
+                failure: {
+                  requestVolume: 10,
+                  minimumHosts: 5,
+                  threshold: 85
+                }
+              }
+            }
+          }
+        ],
+        next: null
+      })
       .onGet('/meshes/alpha-tango-mesh/circuit-breakers').reply(200, {
         total: 0,
         items: [],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,6 +30,7 @@ export default (api) => {
       totalTrafficRouteCount: 0,
       totalTrafficTraceCount: 0,
       totalFaultInjectionCount: 0,
+      totalCircuitBreakerCount: 0,
       totalDataplaneList: [],
       anyDataplanesOffline: null,
       // from mesh
@@ -40,6 +41,7 @@ export default (api) => {
       totalTrafficRouteCountFromMesh: 0,
       totalTrafficTraceCountFromMesh: 0,
       totalFaultInjectionCountFromMesh: 0,
+      totalCircuitBreakerCountFromMesh: 0,
       totalDataplaneCountFromMesh: 0,
       tagline: null,
       version: null,
@@ -66,6 +68,7 @@ export default (api) => {
       getTotalTrafficRouteCount: (state) => state.totalTrafficRouteCount,
       getTotalTrafficTraceCount: (state) => state.totalTrafficTraceCount,
       getTotalFaultInjectionCount: (state) => state.totalFaultInjectionCount,
+      getTotalCircuitBreakerCount: (state) => state.totalCircuitBreakerCount,
       // total counts per single mesh
       getTotalDataplaneCountFromMesh: (state) => state.totalDataplaneCountFromMesh,
       getTotalTrafficRoutesCountFromMesh: (state) => state.totalTrafficRouteCountFromMesh,
@@ -73,8 +76,9 @@ export default (api) => {
       getTotalHealthChecksCountFromMesh: (state) => state.totalHealthCheckCountFromMesh,
       getTotalProxyTemplatesCountFromMesh: (state) => state.totalProxyTemplateCountFromMesh,
       getTotalTrafficLogsFromMesh: (state) => state.totalTrafficLogCountFromMesh,
-      getTotalTrafficTracesFromMesh: (state) => state.totalTrafficTraceCountFromMesh,
-      getFaultInjectionsFromMeshTotalCount: (state) => state.totalFaultInjectionCountFromMesh,
+      getTotalTrafficTracesCountFromMesh: (state) => state.totalTrafficTraceCountFromMesh,
+      getTotalFaultInjectionsCountFromMesh: (state) => state.totalFaultInjectionCountFromMesh,
+      getTotalCircuitBreakersCountFromMesh: (state) => state.totalCircuitBreakerCountFromMesh,
       getVersion: (state) => state.version,
       getTagline: (state) => state.tagline,
       getStatus: (state) => state.status,
@@ -100,6 +104,7 @@ export default (api) => {
       SET_TOTAL_TRAFFIC_TRACE_COUNT: (state, count) => (state.totalTrafficTraceCount = count),
       SET_TOTAL_DP_LIST: (state, dataplanes) => (state.totalDataplaneList = dataplanes),
       SET_TOTAL_FAULT_INJECTION_COUNT: (state, count) => (state.totalFaultInjectionCount = count),
+      SET_TOTAL_CIRCUIT_BREAKER_COUNT: (state, count) => (state.totalCircuitBreakerCount = count),
       SET_TOTAL_DATAPLANE_COUNT_FROM_MESH: (state, count) => (state.totalDataplaneCountFromMesh = count),
       SET_TOTAL_HEALTH_CHECK_COUNT_FROM_MESH: (state, count) => (state.totalHealthCheckCountFromMesh = count),
       SET_TOTAL_PROXY_TEMPLATE_COUNT_FROM_MESH: (state, count) => (state.totalProxyTemplateCountFromMesh = count),
@@ -108,6 +113,7 @@ export default (api) => {
       SET_TOTAL_TRAFFIC_ROUTE_COUNT_FROM_MESH: (state, count) => (state.totalTrafficRouteCountFromMesh = count),
       SET_TOTAL_TRAFFIC_TRACE_COUNT_FROM_MESH: (state, count) => (state.totalTrafficTraceCountFromMesh = count),
       SET_TOTAL_FAULT_INJECTION_COUNT_FROM_MESH: (state, count) => (state.totalFaultInjectionCountFromMesh = count),
+      SET_TOTAL_CIRCUIT_BREAKER_COUNT_FROM_MESH: (state, count) => (state.totalCircuitBreakerCountFromMesh = count),
       SET_ANY_DP_OFFLINE: (state, status) => (state.anyDataplanesOffline = status),
       SET_VERSION: (state, version) => (state.version = version),
       SET_TAGLINE: (state, tagline) => (state.tagline = tagline),
@@ -299,6 +305,21 @@ export default (api) => {
           })
       },
 
+      // get the total number of circuit breakers present
+      fetchCircuitBreakerTotalCount ({ commit }) {
+        const params = { size: 1 }
+
+        return api.getAllCircuitBreakers(params)
+          .then(response => {
+            const total = response.total
+
+            commit('SET_TOTAL_CIRCUIT_BREAKER_COUNT', total)
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      },
+
       /**
        * Total counts (per mesh)
        */
@@ -417,6 +438,21 @@ export default (api) => {
             const total = response.total
 
             commit('SET_TOTAL_FAULT_INJECTION_COUNT_FROM_MESH', total)
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      },
+
+      // get the total number of circuit breakers from a specific mesh
+      fetchCircuitBreakerTotalCountFromMesh ({ commit }, mesh) {
+        const params = { size: 1 }
+
+        return api.getAllCircuitBreakersFromMesh(mesh, params)
+          .then(response => {
+            const total = response.total
+
+            commit('SET_TOTAL_CIRCUIT_BREAKER_COUNT_FROM_MESH', total)
           })
           .catch(error => {
             console.error(error)

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -121,12 +121,12 @@
             :is-empty="entityIsEmpty"
           >
             <div
-              v-for="i in Math.ceil(counts.length / 4)"
+              v-for="i in countCols"
               :key="i"
             >
               <ul>
                 <li
-                  v-for="(item, key) in counts.slice((i - 1) * 4, i * 4)"
+                  v-for="(item, key) in counts.slice((i - 1) * itemsPerCol, i * itemsPerCol)"
                   :key="key"
                 >
                   <h4>{{ item.title }}</h4>
@@ -145,7 +145,6 @@
 import { mapState } from 'vuex'
 import { getSome, humanReadableDate, getOffset } from '@/helpers'
 import sortEntities from '@/mixins/EntitySorter'
-import MetricGrid from '@/components/Metrics/MetricGrid.vue'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
 import DataOverview from '@/components/Skeletons/DataOverview'
@@ -221,7 +220,8 @@ export default {
       hasNext: false,
       previous: [],
       tabGroupTitle: null,
-      entityOverviewTitle: null
+      entityOverviewTitle: null,
+      itemsPerCol: 3
     }
   },
   computed: {
@@ -235,6 +235,10 @@ export default {
         {
           title: 'Dataplanes',
           value: state.totalDataplaneCountFromMesh
+        },
+        {
+          title: 'Circuit Breakers',
+          value: state.totalCircuitBreakerCountFromMesh
         },
         {
           title: 'Fault Injections',
@@ -265,6 +269,9 @@ export default {
           value: state.totalTrafficTraceCountFromMesh
         }
       ]
+    },
+    countCols () {
+      return Math.ceil(this.counts.length / this.itemsPerCol)
     }
   },
   watch: {
@@ -399,7 +406,8 @@ export default {
                 'fetchTrafficPermissionTotalCountFromMesh',
                 'fetchTrafficRouteTotalCountFromMesh',
                 'fetchTrafficTraceTotalCountFromMesh',
-                'fetchFaultInjectionTotalCountFromMesh'
+                'fetchFaultInjectionTotalCountFromMesh',
+                'fetchCircuitBreakerTotalCountFromMesh'
               ]
 
               // run each action

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -114,7 +114,8 @@ export default {
           trafficLogCount: state.totalTrafficLogCount,
           trafficPermissionCount: state.totalTrafficPermissionCount,
           trafficRouteCount: state.totalTrafficRouteCount,
-          trafficTraceCount: state.totalTrafficTraceCount
+          trafficTraceCount: state.totalTrafficTraceCount,
+          circuitBreakerCount: state.totalCircuitBreakerCount
         }
       } else {
         storeVals = {
@@ -125,7 +126,8 @@ export default {
           trafficLogCount: state.totalTrafficLogCountFromMesh,
           trafficPermissionCount: state.totalTrafficPermissionCountFromMesh,
           trafficRouteCount: state.totalTrafficRouteCountFromMesh,
-          trafficTraceCount: state.totalTrafficTraceCountFromMesh
+          trafficTraceCount: state.totalTrafficTraceCountFromMesh,
+          circuitBreakerCount: state.totalCircuitBreakerCountFromMesh
         }
       }
 
@@ -139,6 +141,11 @@ export default {
           metric: 'Dataplanes',
           value: storeVals.dataplaneCount,
           url: `/${this.selectedMesh}/dataplanes`
+        },
+        {
+          metric: 'Circuit Breakers',
+          value: storeVals.circuitBreakerCount,
+          url: `/${this.selectedMesh}/circuit-breakers`
         },
         {
           metric: 'Fault Injections',
@@ -223,7 +230,8 @@ export default {
           'fetchTrafficPermissionTotalCount',
           'fetchTrafficRouteTotalCount',
           'fetchTrafficTraceTotalCount',
-          'fetchFaultInjectionTotalCount'
+          'fetchFaultInjectionTotalCount',
+          'fetchCircuitBreakerTotalCount'
         ]
 
         // run each action
@@ -241,7 +249,8 @@ export default {
           'fetchTrafficPermissionTotalCountFromMesh',
           'fetchTrafficRouteTotalCountFromMesh',
           'fetchTrafficTraceTotalCountFromMesh',
-          'fetchFaultInjectionTotalCountFromMesh'
+          'fetchFaultInjectionTotalCountFromMesh',
+          'fetchCircuitBreakerTotalCountFromMesh'
         ]
 
         // run each action

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -1,0 +1,301 @@
+<template>
+  <div class="circuit-breakers">
+    <FrameSkeleton>
+      <DataOverview
+        :page-size="pageSize"
+        :has-error="hasError"
+        :is-loading="isLoading"
+        :empty-state="empty_state"
+        :display-data-table="true"
+        :table-data="tableData"
+        :table-data-is-empty="tableDataIsEmpty"
+        table-data-function-text="View"
+        table-data-row="name"
+        @tableAction="tableAction"
+        @reloadData="loadData"
+      >
+        <template slot="pagination">
+          <Pagination
+            :has-previous="previous.length > 0"
+            :has-next="hasNext"
+            @next="goToNextPage"
+            @previous="goToPreviousPage"
+          />
+        </template>
+      </DataOverview>
+      <Tabs
+        v-if="isEmpty === false"
+        :has-error="hasError"
+        :is-loading="isLoading"
+        :tabs="tabs"
+        :tab-group-title="tabGroupTitle"
+        initial-tab-override="overview"
+      >
+        <template slot="overview">
+          <LabelList
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+          >
+            <div>
+              <ul>
+                <li
+                  v-for="(val, key) in entity"
+                  :key="key"
+                >
+                  <h4>{{ key }}</h4>
+                  <p>
+                    {{ val }}
+                  </p>
+                </li>
+              </ul>
+            </div>
+          </LabelList>
+        </template>
+        <template slot="yaml">
+          <YamlView
+            lang="yaml"
+            :title="entityOverviewTitle"
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+            :content="rawEntity"
+          />
+        </template>
+      </Tabs>
+    </FrameSkeleton>
+  </div>
+</template>
+
+<script>
+import { getSome } from '@/helpers'
+import sortEntities from '@/mixins/EntitySorter'
+import FormatForCLI from '@/mixins/FormatForCLI'
+import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
+import Pagination from '@/components/Pagination'
+import DataOverview from '@/components/Skeletons/DataOverview'
+import Tabs from '@/components/Utils/Tabs'
+import YamlView from '@/components/Skeletons/YamlView'
+import LabelList from '@/components/Utils/LabelList'
+
+export default {
+  name: 'FaultInjections',
+  metaInfo: {
+    title: 'Fault Injections'
+  },
+  components: {
+    FrameSkeleton,
+    Pagination,
+    DataOverview,
+    Tabs,
+    YamlView,
+    LabelList
+  },
+  mixins: [
+    FormatForCLI,
+    sortEntities
+  ],
+  data () {
+    return {
+      isLoading: true,
+      isEmpty: false,
+      hasError: false,
+      entityIsLoading: true,
+      entityIsEmpty: false,
+      entityHasError: false,
+      tableDataIsEmpty: false,
+      empty_state: {
+        title: 'No Data',
+        message: 'There are no Circuit Breakers present.'
+      },
+      tableData: {
+        headers: [
+          { key: 'actions', hideLabel: true },
+          { label: 'Name', key: 'name' },
+          { label: 'Mesh', key: 'mesh' },
+          { label: 'Type', key: 'type' }
+        ],
+        data: []
+      },
+      tabs: [
+        {
+          hash: '#overview',
+          title: 'Overview'
+        },
+        {
+          hash: '#yaml',
+          title: 'YAML'
+        }
+      ],
+      entity: [],
+      rawEntity: null,
+      firstEntity: null,
+      pageSize: this.$pageSize,
+      pageOffset: null,
+      next: null,
+      hasNext: false,
+      previous: []
+    }
+  },
+  computed: {
+    tabGroupTitle () {
+      const entity = this.entity
+
+      if (entity) {
+        return `Circuit Breaker: ${entity.name}`
+      } else {
+        return null
+      }
+    },
+    entityOverviewTitle () {
+      const entity = this.entity
+
+      if (entity) {
+        return `Entity Overview for ${entity.name}`
+      } else {
+        return null
+      }
+    },
+    formattedRawEntity () {
+      const entity = this.formatForCLI(this.rawEntity)
+
+      return entity
+    }
+  },
+  watch: {
+    '$route' (to, from) {
+      this.init()
+    }
+  },
+  beforeMount () {
+    this.init()
+  },
+  methods: {
+    init () {
+      this.loadData()
+    },
+    goToPreviousPage () {
+      this.pageOffset = this.previous.pop()
+      this.next = null
+
+      this.loadData()
+    },
+    goToNextPage () {
+      this.previous.push(this.pageOffset)
+      this.pageOffset = this.next
+      this.next = null
+
+      this.loadData()
+    },
+    tableAction (ev) {
+      const data = ev
+
+      // reset back to the first tab
+      this.$store.dispatch('updateSelectedTab', this.tabs[0].hash)
+
+      // set the active table row
+      this.$store.dispatch('updateSelectedTableRow', data.name)
+
+      // load the data into the tabs
+      this.getEntity(data)
+    },
+    loadData () {
+      this.isLoading = true
+
+      const mesh = this.$route.params.mesh
+
+      const params = {
+        size: this.pageSize,
+        offset: this.pageOffset
+      }
+
+      const endpoint = (mesh === 'all')
+        ? this.$api.getAllCircuitBreakers(params)
+        : this.$api.getAllCircuitBreakersFromMesh(mesh)
+
+      const getCircuitBreakers = () => {
+        return endpoint
+          .then(response => {
+            if (response.items.length > 0) {
+              const items = response.items
+
+              // sort the table data by name and the mesh it's associated with
+              this.sortEntities(items)
+
+              // set the first item as the default for initial load
+              this.firstEntity = items[0].name
+
+              // load the YAML entity for the first item on page load
+              this.getEntity(items[0])
+
+              // set the selected table row for the first item on page load
+              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+
+              this.tableData.data = [...items]
+              this.tableDataIsEmpty = false
+              this.isEmpty = false
+            } else {
+              this.tableData.data = []
+              this.tableDataIsEmpty = true
+              this.isEmpty = true
+
+              this.getEntity(null)
+            }
+          })
+          .catch(error => {
+            this.hasError = true
+            this.isEmpty = true
+
+            console.error(error)
+          })
+          .finally(() => {
+            setTimeout(() => {
+              this.isLoading = false
+            }, process.env.VUE_APP_DATA_TIMEOUT)
+          })
+      }
+
+      getCircuitBreakers()
+    },
+    getEntity (entity) {
+      this.entityIsLoading = true
+      this.entityIsEmpty = false
+
+      const mesh = this.$route.params.mesh
+
+      if (entity && entity !== null) {
+        const entityMesh = (mesh === 'all')
+          ? entity.mesh
+          : mesh
+
+        return this.$api.getCircuitBreaker(entityMesh, entity.name)
+          .then(response => {
+            if (response) {
+              const selected = ['type', 'name', 'mesh']
+
+              this.entity = getSome(response, selected)
+              this.rawEntity = response
+            } else {
+              this.entity = null
+              this.entityIsEmpty = true
+            }
+          })
+          .catch(error => {
+            this.entityHasError = true
+            console.error(error)
+          })
+          .finally(() => {
+            setTimeout(() => {
+              this.entityIsLoading = false
+            }, process.env.VUE_APP_DATA_TIMEOUT)
+          })
+      } else {
+        setTimeout(() => {
+          this.entityIsEmpty = true
+          this.entityIsLoading = false
+        }, process.env.VUE_APP_DATA_TIMEOUT)
+      }
+    }
+  }
+}
+</script>


### PR DESCRIPTION
This is a new view for handling Circuit Breakers ([#781](https://github.com/Kong/kuma/pull/781)) in Kuma.

After running `yarn serve`, you can access Circuit Breakers at `http://localhost:8080/#/default/circuit-breakers`.

This also adds 3 new Circuit Breaker endpoints:
1. `getAllCircuitBreakers` - This gets all CBs across all Meshes
2. `getAllCircuitBreakersFromMesh` - Gets all CBs from a specific Mesh
3. `getCircuitBreaker` - Get a specific CB from a specific Mesh