### PR TITLE
Upgrade notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "axios": "^0.19.0",
     "axios-mock-adapter": "^1.17.0",
     "core-js": "^2.6.5",
+    "semver-compare": "^1.0.0",
     "tailwindcss": "^1.1.2",
     "vue": "^2.6.10",
     "vue-meta": "^2.3.1",

--- a/src/assets/styles/components.css
+++ b/src/assets/styles/components.css
@@ -82,3 +82,31 @@
   line-height: 0;
   max-height: 18px;
 }
+
+.external-link-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-family: var(--font-family-sans);
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.25;
+  text-decoration: none;
+  vertical-align: middle;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  cursor: pointer;
+  color: #fff !important;
+  background-color: var(--KButtonPrimaryBase);
+  text-decoration: none !important;
+}
+
+.external-link-btn:after {
+  display: inline-block;
+  content: "\203A";
+  margin-left: 5px;
+}
+
+.external-link-btn:hover {
+  background-color: #0089eb;
+}

--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -42,7 +42,7 @@
   --brand-color-6: var(--logo-purple);
 
   /* Topbar */
-  --topbar-height: 4rem;
+  --topbar-height: 92px;
 
   /* Content areas */
   --global-content-max-width: 100rem;

--- a/src/components/Global/Header.vue
+++ b/src/components/Global/Header.vue
@@ -14,7 +14,7 @@
         </router-link>
       </div>
       <div
-        v-if="!$route.meta.hideStatus && status === 'OK'"
+        v-if="showStatus"
         class="px-4"
       >
         <status
@@ -46,7 +46,10 @@ export default {
       status: 'getStatus',
       // the currently selected mesh
       currentMesh: 'getSelectedMesh'
-    })
+    }),
+    showStatus () {
+      return !this.$route.meta.hideStatus && this.status === 'OK'
+    }
   },
   beforeMount () {
     this.getGuiStatus()

--- a/src/components/Global/Header.vue
+++ b/src/components/Global/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="main-header p-4">
     <div class="main-header__content flex justify-between items-center -mx-4">
-      <div class="px-4">
+      <div class="py-1 md:py-0 md:px-4">
         <router-link
           :to="{ name: 'global-overview' }"
           exact
@@ -13,14 +13,19 @@
           >
         </router-link>
       </div>
-      <div
-        v-if="showStatus"
-        class="px-4"
-      >
-        <status
-          :active="guiStatus"
-          :content="statusContent"
-        />
+      <div class="md:flex md:justify-between md:items-center">
+        <div class="py-1 md:py-0 md:px-4 upgrade-check-wrapper">
+          <UpgradeCheck />
+        </div>
+        <div
+          v-if="showStatus"
+          class="py-1 md:py-0 md:px-4"
+        >
+          <status
+            :active="guiStatus"
+            :content="statusContent"
+          />
+        </div>
       </div>
     </div>
   </header>
@@ -29,10 +34,12 @@
 <script>
 import { mapGetters } from 'vuex'
 import Status from '@/components/Utils/Status'
+import UpgradeCheck from '@/components/Utils/UpgradeCheck'
 
 export default {
   components: {
-    Status
+    Status,
+    UpgradeCheck
   },
   data () {
     return {
@@ -102,6 +109,16 @@ export default {
     width: auto;
     height: auto;
     max-height: 46px;
+  }
+}
+
+.upgrade-check-wrapper {
+  margin-left: auto;
+}
+
+@media screen and (max-width: 599px) {
+  .upgrade-check-wrapper {
+    display: none;
   }
 }
 </style>

--- a/src/components/Skeletons/CardSkeleton.vue
+++ b/src/components/Skeletons/CardSkeleton.vue
@@ -18,7 +18,7 @@
               v-if="externalLink"
               :href="cardActionRoute"
               target="_blank"
-              class="external-link"
+              class="external-link-btn"
             >
               {{ cardActionButtonText }}
             </a>
@@ -98,39 +98,6 @@ export default {
 
   &, * {
     text-align: center;
-  }
-}
-
-.external-link {
-  display: -webkit-inline-box;
-  display: inline-flex;
-  align-items: center;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  font-family: var(--font-family-sans);
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.25;
-  text-decoration: none;
-  vertical-align: middle;
-  color: var(--tblack-70);
-  border: 1px solid transparent;
-  border-radius: 3px;
-  -webkit-transition: all .2s ease-in-out;
-  transition: all .2s ease-in-out;
-  cursor: pointer;
-
-  // primary styles
-  color: #fff;
-  background-color: var(--KButtonPrimaryBase);
-
-  &:after {
-    display: inline-block;
-    content: "\203A";
-    margin-left: 5px;
-  }
-
-  &:hover {
-    background-color: #0089eb;
   }
 }
 </style>

--- a/src/components/Utils/UpgradeCheck.vue
+++ b/src/components/Utils/UpgradeCheck.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="upgrade-check">
+    <KAlert
+      v-if="showNotice"
+      appearance="warning"
+    >
+      <template slot="alertMessage">
+        <div class="alert-content">
+          <div>
+            You are running an outdated version of Kuma.
+          </div>
+          <div>
+            <a
+              :href="url"
+              target="_blank"
+              class="external-link"
+            >
+              Upgrade
+            </a>
+          </div>
+        </div>
+      </template>
+    </KAlert>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UpgradeCheck',
+  data () {
+    return {
+      url: 'https://kuma.io/install/latest/'
+    }
+  },
+  computed: {
+    showNotice () {
+      return true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.upgrade-check {
+  margin: 0 0 var(--spacing-xl) 0;
+}
+
+.alert-content {
+  display: flex;
+  align-items: center;
+
+  > *:first-of-type {
+    margin-right: var(--spacing-md);
+  }
+}
+
+.action-button.action-button {
+  text-decoration: none;
+}
+</style>

--- a/src/components/Utils/UpgradeCheck.vue
+++ b/src/components/Utils/UpgradeCheck.vue
@@ -101,13 +101,13 @@ export default {
                 new Date(lastVersionCheckDate).getMonth() + 3,
                 new Date(lastVersionCheckDate).getDate()
               )
+            }
 
-              // compare dates and handle the notice accordingly
-              if (today.getTime() >= later.getTime()) {
-                this.showNotice = true
-              } else {
-                this.showNotice = false
-              }
+            // compare dates and handle the notice accordingly
+            if (today.getTime() >= later.getTime()) {
+              this.showNotice = true
+            } else {
+              this.showNotice = false
             }
           }
         })

--- a/src/components/Utils/UpgradeCheck.vue
+++ b/src/components/Utils/UpgradeCheck.vue
@@ -76,32 +76,14 @@ export default {
               this.showNotice = false
             }
           } else {
-            // if we can't fetch the latest version from the Kuma website,
-            // we will store today's date as a reference point.
-            const lastVersionCheckDate = localStorage.getItem('lastVersionCheckDate')
-            let later
-            const today = new Date(
-              new Date().getFullYear(),
-              new Date().getMonth(),
-              new Date().getDate()
+            const timespan = 3 // months
+            const today = new Date()
+            const refDate = new Date('2020-06-03 12:00:00')
+            const later = new Date(
+              refDate.getFullYear(),
+              refDate.getMonth() + timespan,
+              refDate.getDate()
             )
-
-            if (!lastVersionCheckDate) {
-              // store today's date in local storage if it's not already present
-              localStorage.setItem('lastVersionCheckDate', today)
-
-              later = new Date(
-                today.getFullYear(),
-                today.getMonth() + 3,
-                today.getDate()
-              )
-            } else {
-              later = new Date(
-                new Date(lastVersionCheckDate).getFullYear(),
-                new Date(lastVersionCheckDate).getMonth() + 3,
-                new Date(lastVersionCheckDate).getDate()
-              )
-            }
 
             // compare dates and handle the notice accordingly
             if (today.getTime() >= later.getTime()) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,11 @@
 module.exports = {
+  purge: [
+    './src/**/*.vue'
+  ],
   theme: {
     container: {
       center: true,
-      padding: "2rem"
+      padding: '2rem'
     }
   }
-};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9726,6 +9726,11 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"


### PR DESCRIPTION
This will alert the user if they are running a version of Kuma that is older than the latest version available. It also handles situations where the internet might not be accessible.

* If the internet is accessible from the GUI, this will simply get the version from https://kuma.io/latest_version, compare it to the current version the user is running, and determine whether or not the notice should display
* If the internet is NOT accessible from the GUI, the component will store today's date in localStorage (for accessing it later) and 3 months from that date, it will display the notice

In the offline scenario, the GUI assumes there will be new releases within that 3 month span. We can adjust this gap in the future if needed. While having access to the internet makes this simple, we can still serve a solution to users that have Kuma setup in use cases where it's kept isolated from external networks.