### PR TITLE
Undefined titles in tab view of Dataplanes

### DIFF
--- a/src/views/Entities/Dataplanes.vue
+++ b/src/views/Entities/Dataplanes.vue
@@ -168,31 +168,15 @@ export default {
       pageOffset: null,
       next: null,
       hasNext: false,
-      previous: []
+      previous: [],
+      tabGroupTitle: null,
+      entityOverviewTitle: null
     }
   },
   computed: {
     ...mapGetters({
       environment: 'getEnvironment'
     }),
-    tabGroupTitle () {
-      const entity = this.entity
-
-      if (entity) {
-        return `Dataplane: ${entity.name}`
-      } else {
-        return null
-      }
-    },
-    entityOverviewTitle () {
-      const entity = this.entity
-
-      if (entity) {
-        return `Entity Overview for ${entity.name}`
-      } else {
-        return null
-      }
-    },
     dataplaneWizardRoute () {
       // we change the route to the Dataplane
       // wizard based on environment.
@@ -482,8 +466,10 @@ export default {
               }
 
               this.entity = newEntity
-
               this.rawEntity = response
+
+              this.tabGroupTitle = `Mesh: ${newEntity.basicData.name}`
+              this.entityOverviewTitle = `Entity Overview for ${newEntity.basicData.name}`
             } else {
               this.entity = null
               this.entityIsEmpty = true


### PR DESCRIPTION
There were some old computed values still in place that needed to be replaced. The titles were being derived from them. This PR matches their behavior to the new approach used in other views.