### PR TITLE
Entity routes

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=false
+VUE_APP_MOCK_API_ENABLED=true
 VUE_APP_KUMA_CONFIG=/dev-api-config.json

--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -369,6 +369,10 @@ export default {
   .k-button:after, button:after {
     display: none !important;
   }
+
+  .k-button {
+    margin-left: var(--spacing-xs);
+  }
 }
 
 .empty-state-wrapper {

--- a/src/components/Utils/EntityURLControl.vue
+++ b/src/components/Utils/EntityURLControl.vue
@@ -1,0 +1,44 @@
+<template>
+  <KClipboardProvider v-slot="{ copyToClipboard }">
+    <KPop placement="bottom">
+      <KButton
+        appearance="secondary"
+        size="small"
+        @click="() => { copyToClipboard(url) }"
+      >
+        <KIcon
+          slot="icon"
+          icon="externalLink"
+        />
+        {{ copyButtonText }}
+      </KButton>
+      <div slot="content">
+        <p>{{ confirmationText }}</p>
+      </div>
+    </KPop>
+  </KClipboardProvider>
+</template>
+
+<script>
+export default {
+  name: 'EntityURLControl',
+  props: {
+    url: {
+      type: String,
+      required: true
+    },
+    copyButtonText: {
+      type: String,
+      default: 'Copy URL'
+    },
+    confirmationText: {
+      type: String,
+      default: 'URL copied to clipboard!'
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/src/components/Utils/OnboardingCheck.vue
+++ b/src/components/Utils/OnboardingCheck.vue
@@ -51,11 +51,11 @@ export default {
   },
   computed: {
     ...mapState({
-      dataplanes: 'totalDataplaneCount',
+      dpCount: 'totalDataplaneCount',
       meshes: 'meshes'
     }),
     showNotice () {
-      return !this.dataplanes.length && this.onlyDefaultMesh === true
+      return this.dpCount && this.dpCount === 0 && this.onlyDefaultMesh === true
     }
   },
   watch: {

--- a/src/components/Utils/OnboardingCheck.vue
+++ b/src/components/Utils/OnboardingCheck.vue
@@ -55,7 +55,7 @@ export default {
       meshes: 'meshes'
     }),
     showNotice () {
-      return this.dpCount && this.dpCount === 0 && this.onlyDefaultMesh === true
+      return (this.dpCount !== undefined && this.dpCount === 0) && this.onlyDefaultMesh === true
     }
   },
   watch: {

--- a/src/components/Utils/Tabs.vue
+++ b/src/components/Utils/Tabs.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="tab-container">
     <header
-      v-if="tabGroupTitle && isReady"
+      v-if="$slots.tabHeader && isReady"
       class="tab__header"
     >
-      <h3 class="tab__header__title">
+      <slot name="tabHeader" />
+      <!-- <h3 class="tab__header__title">
         {{ tabGroupTitle }}
-      </h3>
+      </h3> -->
     </header>
 
     <div
@@ -157,12 +158,16 @@ export default {
 .k-tabs ul .tab-link {
   text-decoration: none !important;
 }
+
+.tab__header .k-button:after {
+  display: none !important;
+}
 </style>
 
 <style lang="scss" scoped>
 .tab-container {
   --tab-container-margin: var(--spacing-lg) 0 0 0;
-  --tab-header-margin: 0 0 var(--spacing-md) 0;
+  --tab-header-margin: 0 -10px var(--spacing-md) -10px;
   --tab-header-padding: 0 var(--spacing-md);
   --tab-header-title-font-size: var(--type-md);
   --tab-header-title-font-weight: 500;
@@ -183,13 +188,19 @@ export default {
 }
 
 .tab__header {
+  display: flex;
+  align-items: center;
   margin: var(--tab-header-margin);
   padding: var(--tab-header-padding);
-}
 
-.tab__header__title {
-  font-size: var(--tab-header-title-font-size);
-  font-weight: var(--tab-header-title-font-weight);
+  h1, h2, h3, h4, h5, h6 {
+    font-size: var(--tab-header-title-font-size);
+    font-weight: var(--tab-header-title-font-weight);
+  }
+
+  > div {
+    padding: 0 10px;
+  }
 }
 
 .tab__nav {

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -190,7 +190,7 @@ export default class Kuma {
   }
 
   // get health check details
-  getHealthCheckFromMesh (mesh, name, params) {
+  getHealthCheck (mesh, name, params) {
     return this.client.get(`/meshes/${mesh}/health-checks/${name}`, { params })
   }
 

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -317,20 +317,39 @@ export default class Mock {
             conf: {
               backend: 'my-zipkin'
             }
-          },
+          }
+        ]
+      })
+      .onGet('/meshes/default/traffic-traces/tt-1').reply(200, {
+        type: 'TrafficTrace',
+        mesh: 'mesh-1',
+        name: 'tt-1',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        conf: {
+          backend: 'my-zipkin'
+        },
+        selectors: [
           {
-            type: 'TrafficTrace',
-            mesh: 'default',
-            name: 'tt-3',
-            selectors: [
-              {
-                match: {
-                  service: '*'
-                }
-              }
-            ],
-            conf: {
-              backend: 'my-zipkin'
+            match: {
+              service: '*'
+            }
+          }
+        ]
+      })
+      .onGet('/meshes/default/traffic-traces/traffic-trace-02').reply(200, {
+        type: 'TrafficTrace',
+        mesh: 'mesh-1',
+        name: 'traffic-trace-02',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        conf: {
+          backend: 'my-zipkin'
+        },
+        selectors: [
+          {
+            match: {
+              service: '*'
             }
           }
         ]
@@ -1351,7 +1370,7 @@ export default class Mock {
           ]
         }
       })
-      .onGet('/traffic-logs').reply(200, {
+      .onGet('/meshes/default/traffic-logs').reply(200, {
         items: [
           {
             type: 'TrafficLog',
@@ -1398,54 +1417,58 @@ export default class Mock {
             conf: {
               backend: 'file'
             }
-          },
-          {
-            type: 'TrafficLog',
-            mesh: 'helloworld',
-            name: 'tl-alpha-tango',
-            sources: [
-              {
-                match: {
-                  service: 'web',
-                  version: '1.0'
-                }
-              }
-            ],
-            destinations: [
-              {
-                match: {
-                  service: 'backend'
-                }
-              }
-            ],
-            conf: {
-              backend: 'file'
-            }
-          },
-          {
-            type: 'TrafficLog',
-            mesh: 'my-silly-mesh-name',
-            name: 'tl-cat-dog-donut-12',
-            sources: [
-              {
-                match: {
-                  service: 'web',
-                  version: '1.0'
-                }
-              }
-            ],
-            destinations: [
-              {
-                match: {
-                  service: 'backend'
-                }
-              }
-            ],
-            conf: {
-              backend: 'file'
-            }
           }
         ]
+      })
+      .onGet('/meshes/default/traffic-logs/tl-1').reply(200, {
+        type: 'TrafficLog',
+        mesh: 'mesh-1',
+        name: 'tl-1',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        sources: [
+          {
+            match: {
+              service: 'web',
+              version: '1.0'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        conf: {
+          backend: 'file'
+        }
+      })
+      .onGet('/meshes/default/traffic-logs/tl-123').reply(200, {
+        type: 'TrafficLog',
+        mesh: 'mesh-1',
+        name: 'tl-123',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        sources: [
+          {
+            match: {
+              service: 'web',
+              version: '1.0'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        conf: {
+          backend: 'file'
+        }
       })
       .onGet('/traffic-permissions').reply(200, {
         items: [
@@ -1585,6 +1608,69 @@ export default class Mock {
                 }
               }
             ]
+          }
+        ]
+      })
+      .onGet('/meshes/default/traffic-permissions/tp-1').reply(200, {
+        type: 'TrafficPermission',
+        mesh: 'mesh-1',
+        name: 'tp-1',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        sources: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'redis'
+            }
+          }
+        ]
+      })
+      .onGet('/meshes/default/traffic-permissions/tp-1234').reply(200, {
+        type: 'TrafficPermission',
+        mesh: 'mesh-1',
+        name: 'tp-1234',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        sources: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'redis'
+            }
+          }
+        ]
+      })
+      .onGet('/meshes/default/traffic-permissions/tp-alpha-tango-donut').reply(200, {
+        type: 'TrafficPermission',
+        mesh: 'mesh-1',
+        name: 'tp-alpha-tango-donut',
+        creationTime: '2020-05-12T12:31:45.606217+02:00',
+        modificationTime: '2020-05-12T12:31:45.606217+02:00',
+        sources: [
+          {
+            match: {
+              service: 'backend'
+            }
+          }
+        ],
+        destinations: [
+          {
+            match: {
+              service: 'redis'
+            }
           }
         ]
       })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -46,7 +46,8 @@ export default (api) => {
       status: null,
       selectedTab: '#overview',
       selectedTableRow: null,
-      storedWizardData: null
+      storedWizardData: null,
+      itemQueryNamespace: 'item'
     },
     getters: {
       getOnboardingStatus: (state) => state.onboardingComplete,
@@ -82,7 +83,8 @@ export default (api) => {
       getSelectedTab: (state) => state.selectedTab,
       getSelectedTableRow: (state) => state.selectedTableRow,
       getEnvironment: (state) => state.environment,
-      getStoredWizardData: (state) => state.storedWizardData
+      getStoredWizardData: (state) => state.storedWizardData,
+      getItemQueryNamespace: (state) => state.itemQueryNamespace
     },
     mutations: {
       SET_ONBOARDING_STATUS: (state, status) => (state.onboardingComplete = status),

--- a/src/views/Entities/Dataplanes.vue
+++ b/src/views/Entities/Dataplanes.vue
@@ -32,10 +32,7 @@
             appearance="primary"
             size="small"
             :to="{
-              name: 'dataplanes',
-              params: {
-                mesh: 'all'
-              }
+              name: 'dataplanes'
             }"
           >
             <span class="custom-control-icon">
@@ -260,14 +257,14 @@ export default {
     },
     shareUrl () {
       const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
       const shareUrl = () => {
         if (this.$route.query.ns) {
           return this.$route.fullPath
-        } else if (this.entityNamespace) {
-          return `${urlRoot}${this.$route.fullPath}?ns=${this.entityNamespace}`
         }
 
-        return null
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
       }
 
       return shareUrl()

--- a/src/views/Entities/Dataplanes.vue
+++ b/src/views/Entities/Dataplanes.vue
@@ -58,9 +58,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -152,6 +159,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import { getSome, humanReadableDate, getOffset } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
@@ -166,6 +174,7 @@ export default {
     title: 'Dataplanes'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -225,6 +234,7 @@ export default {
       hasNext: false,
       previous: [],
       tabGroupTitle: null,
+      entityNamespace: null,
       entityOverviewTitle: null,
       showmTLSTab: false
     }
@@ -247,6 +257,20 @@ export default {
       const storedVersion = this.$store.getters.getVersion
 
       return (storedVersion !== null) ? storedVersion : 'latest'
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        } else if (this.entityNamespace) {
+          return `${urlRoot}${this.$route.fullPath}?ns=${this.entityNamespace}`
+        }
+
+        return null
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -600,6 +624,7 @@ export default {
 
               newEntity().then(i => {
                 this.entity = i
+                this.entityNamespace = i.basicData.name
                 this.tabGroupTitle = `Mesh: ${i.basicData.name}`
                 this.entityOverviewTitle = `Entity Overview for ${i.basicData.name}`
               })

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -28,9 +28,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -69,6 +76,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FormatForCLI from '@/mixins/FormatForCLI'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
@@ -84,6 +92,7 @@ export default {
     title: 'Circuit Breakers'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -160,6 +169,20 @@ export default {
       const entity = this.formatForCLI(this.rawEntity)
 
       return entity
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -231,12 +254,12 @@ export default {
               return response
             }
 
-            const itemSelect = items()
+            const entityList = items()
 
             if (items()) {
               const firstItem = query
-                ? itemSelect
-                : itemSelect[0]
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
               this.firstEntity = firstItem.name
@@ -248,8 +271,8 @@ export default {
               this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
               this.tableData.data = query
-                ? [itemSelect]
-                : itemSelect
+                ? [entityList]
+                : entityList
 
               this.tableDataIsEmpty = false
               this.isEmpty = false

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'circuit-breakers'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'fault-injections'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -28,9 +28,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -69,6 +76,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FormatForCLI from '@/mixins/FormatForCLI'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
@@ -84,6 +92,7 @@ export default {
     title: 'Fault Injections'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -160,6 +169,20 @@ export default {
       const entity = this.formatForCLI(this.rawEntity)
 
       return entity
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -202,36 +225,55 @@ export default {
     loadData () {
       this.isLoading = true
 
-      const mesh = this.$route.params.mesh
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
 
       const params = {
         size: this.pageSize,
         offset: this.pageOffset
       }
 
-      const endpoint = (mesh === 'all')
-        ? this.$api.getAllFaultInjections(params)
-        : this.$api.getAllFaultInjectionsFromMesh(mesh)
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllFaultInjections(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getFaultInjection(mesh, query, params)
+        }
+
+        return this.$api.getAllFaultInjectionsFromMesh(mesh)
+      }
 
       const getFaultInjections = () => {
-        return endpoint
+        return endpoint()
           .then(response => {
-            if (response.items.length > 0) {
-              const items = response.items
+            const items = () => {
+              if (response.items && response.items.length > 0) {
+                return this.sortEntities(response.items)
+              }
 
-              // sort the table data by name and the mesh it's associated with
-              this.sortEntities(items)
+              return response
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
-              this.firstEntity = items[0].name
+              this.firstEntity = firstItem.name
 
               // load the YAML entity for the first item on page load
-              this.getEntity(items[0])
+              this.getEntity(firstItem)
 
               // set the selected table row for the first item on page load
-              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
-              this.tableData.data = [...items]
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
               this.tableDataIsEmpty = false
               this.isEmpty = false
             } else {

--- a/src/views/Policies/HealthChecks.vue
+++ b/src/views/Policies/HealthChecks.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'health-checks'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"
@@ -28,9 +44,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -68,6 +91,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
@@ -82,6 +106,7 @@ export default {
     title: 'Health Checks'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -152,6 +177,20 @@ export default {
       } else {
         return null
       }
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -194,36 +233,55 @@ export default {
     loadData () {
       this.isLoading = true
 
-      const mesh = this.$route.params.mesh
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
 
       const params = {
         size: this.pageSize,
         offset: this.pageOffset
       }
 
-      const endpoint = (mesh === 'all')
-        ? this.$api.getAllHealthChecks(params)
-        : this.$api.getAllHealthChecksFromMesh(mesh)
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllHealthChecks(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getHealthCheck(mesh, query, params)
+        }
+
+        return this.$api.getAllHealthChecksFromMesh(mesh)
+      }
 
       const getHealthChecks = () => {
-        return endpoint
+        return endpoint()
           .then(response => {
-            if (response.items.length > 0) {
-              const items = response.items
+            const items = () => {
+              if (response.items && response.items.length > 0) {
+                return this.sortEntities(response.items)
+              }
 
-              // sort the table data by name and the mesh it's associated with
-              this.sortEntities(items)
+              return response
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
-              this.firstEntity = items[0].name
+              this.firstEntity = firstItem.name
 
               // load the YAML entity for the first item on page load
-              this.getEntity(items[0])
+              this.getEntity(firstItem)
 
               // set the selected table row for the first item on page load
-              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
-              this.tableData.data = [...items]
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
               this.tableDataIsEmpty = false
               this.isEmpty = false
             } else {
@@ -260,7 +318,7 @@ export default {
           ? entity.mesh
           : mesh
 
-        return this.$api.getHealthCheckFromMesh(entityMesh, entity.name)
+        return this.$api.getHealthCheck(entityMesh, entity.name)
           .then(response => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/ProxyTemplates.vue
+++ b/src/views/Policies/ProxyTemplates.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'proxy-templates'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"
@@ -28,9 +44,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -68,6 +91,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
@@ -82,6 +106,7 @@ export default {
     title: 'Proxy Templates'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -152,6 +177,20 @@ export default {
       } else {
         return null
       }
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -194,36 +233,55 @@ export default {
     loadData () {
       this.isLoading = true
 
-      const mesh = this.$route.params.mesh
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
 
       const params = {
         size: this.pageSize,
         offset: this.pageOffset
       }
 
-      const endpoint = (mesh === 'all')
-        ? this.$api.getAllProxyTemplates(params)
-        : this.$api.getAllProxyTemplatesFromMesh(mesh)
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllProxyTemplates(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getProxyTemplate(mesh, query)
+        }
+
+        return this.$api.getAllProxyTemplatesFromMesh(mesh)
+      }
 
       const getProxyTemplates = () => {
-        return endpoint
+        return endpoint()
           .then(response => {
-            if (response.items.length > 0) {
-              const items = response.items
+            const items = () => {
+              if (response.items && response.items.length > 0) {
+                return this.sortEntities(response.items)
+              }
 
-              // sort the table data by name and the mesh it's associated with
-              this.sortEntities(items)
+              return response
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
-              this.firstEntity = items[0].name
+              this.firstEntity = firstItem.name
 
               // load the YAML entity for the first item on page load
-              this.getEntity(items[0])
+              this.getEntity(firstItem)
 
               // set the selected table row for the first item on page load
-              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
-              this.tableData.data = [...items]
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
               this.tableDataIsEmpty = false
               this.isEmpty = false
             } else {

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'traffic-permissions'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"
@@ -31,6 +47,14 @@
         :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -68,6 +92,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
@@ -82,6 +107,7 @@ export default {
     title: 'Traffic Permissions'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -152,6 +178,20 @@ export default {
       } else {
         return null
       }
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -194,36 +234,55 @@ export default {
     loadData () {
       this.isLoading = true
 
-      const mesh = this.$route.params.mesh
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
 
       const params = {
         size: this.pageSize,
         offset: this.pageOffset
       }
 
-      const endpoint = (mesh === 'all')
-        ? this.$api.getAllTrafficPermissions(params)
-        : this.$api.getAllTrafficPermissionsFromMesh(mesh)
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllTrafficPermissions(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getTrafficPermission(mesh, query)
+        }
+
+        return this.$api.getAllTrafficPermissionsFromMesh(mesh)
+      }
 
       const getTrafficPermissions = () => {
-        return endpoint
+        return endpoint()
           .then(response => {
-            if (response.items.length > 0) {
-              const items = response.items
+            const items = () => {
+              if (response.items && response.items.length > 0) {
+                return this.sortEntities(response.items)
+              }
 
-              // sort the table data by name and the mesh it's associated with
-              this.sortEntities(items)
+              return response
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
-              this.firstEntity = items[0].name
+              this.firstEntity = firstItem.name
 
               // load the YAML entity for the first item on page load
-              this.getEntity(items[0])
+              this.getEntity(firstItem)
 
               // set the selected table row for the first item on page load
-              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
-              this.tableData.data = [...items]
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
               this.tableDataIsEmpty = false
               this.isEmpty = false
             } else {

--- a/src/views/Policies/TrafficRoutes.vue
+++ b/src/views/Policies/TrafficRoutes.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'traffic-routes'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"
@@ -28,9 +44,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -68,6 +91,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
@@ -82,6 +106,7 @@ export default {
     title: 'Traffic Routes'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -152,6 +177,20 @@ export default {
       } else {
         return null
       }
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -194,36 +233,55 @@ export default {
     loadData () {
       this.isLoading = true
 
-      const mesh = this.$route.params.mesh
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
 
       const params = {
         size: this.pageSize,
         offset: this.pageOffset
       }
 
-      const endpoint = (mesh === 'all')
-        ? this.$api.getAllTrafficRoutes(params)
-        : this.$api.getAllTrafficRoutesFromMesh(mesh)
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllTrafficRoutes(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getTrafficRoute(mesh, query)
+        }
+
+        return this.$api.getAllTrafficRoutesFromMesh(mesh)
+      }
 
       const getTrafficRoutes = () => {
-        return endpoint
+        return endpoint()
           .then(response => {
-            if (response.items.length > 0) {
-              const items = response.items
+            const items = () => {
+              if (response.items && response.items.length > 0) {
+                return this.sortEntities(response.items)
+              }
 
-              // sort the table data by name and the mesh it's associated with
-              this.sortEntities(items)
+              return response
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
-              this.firstEntity = items[0].name
+              this.firstEntity = firstItem.name
 
               // load the YAML entity for the first item on page load
-              this.getEntity(items[0])
+              this.getEntity(firstItem)
 
               // set the selected table row for the first item on page load
-              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
-              this.tableData.data = [...items]
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
               this.tableDataIsEmpty = false
               this.isEmpty = false
             } else {

--- a/src/views/Policies/TrafficTraces.vue
+++ b/src/views/Policies/TrafficTraces.vue
@@ -14,6 +14,22 @@
         @tableAction="tableAction"
         @reloadData="loadData"
       >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'traffic-traces'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
         <template slot="pagination">
           <Pagination
             :has-previous="previous.length > 0"
@@ -28,9 +44,16 @@
         :has-error="hasError"
         :is-loading="isLoading"
         :tabs="tabs"
-        :tab-group-title="tabGroupTitle"
         initial-tab-override="overview"
       >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
         <template slot="overview">
           <LabelList
             :has-error="entityHasError"
@@ -68,6 +91,7 @@
 
 <script>
 import { getSome } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import Pagination from '@/components/Pagination'
@@ -82,6 +106,7 @@ export default {
     title: 'Traffic Traces'
   },
   components: {
+    EntityURLControl,
     FrameSkeleton,
     Pagination,
     DataOverview,
@@ -152,6 +177,20 @@ export default {
       } else {
         return null
       }
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
     }
   },
   watch: {
@@ -194,36 +233,55 @@ export default {
     loadData () {
       this.isLoading = true
 
-      const mesh = this.$route.params.mesh
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
 
       const params = {
         size: this.pageSize,
         offset: this.pageOffset
       }
 
-      const endpoint = (mesh === 'all')
-        ? this.$api.getAllTrafficTraces(params)
-        : this.$api.getAllTrafficTracesFromMesh(mesh)
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllTrafficTraces(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getTrafficTrace(mesh, query)
+        }
+
+        return this.$api.getAllTrafficTraces(mesh)
+      }
 
       const getTrafficTraces = () => {
-        return endpoint
+        return endpoint()
           .then(response => {
-            if (response.items.length > 0) {
-              const items = response.items
+            const items = () => {
+              if (response.items && response.items.length > 0) {
+                return this.sortEntities(response.items)
+              }
 
-              // sort the table data by name and the mesh it's associated with
-              this.sortEntities(items)
+              return response
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
 
               // set the first item as the default for initial load
-              this.firstEntity = items[0].name
+              this.firstEntity = firstItem.name
 
               // load the YAML entity for the first item on page load
-              this.getEntity(items[0])
+              this.getEntity(firstItem)
 
               // set the selected table row for the first item on page load
-              this.$store.dispatch('updateSelectedTableRow', this.firstEntity)
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
 
-              this.tableData.data = [...items]
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
               this.tableDataIsEmpty = false
               this.isEmpty = false
             } else {


### PR DESCRIPTION
This PR adds a new feature where users can copy a URL that displays a specific entity's information, vs displaying a list of entities.

On all policy views and the Dataplanes view, there is a new button for copying a link for the selected entity - [screenshot](https://share.getcloudapp.com/2Nu5555P). When clicked it will provide a URL like this:

```
http://localhost:8080#/default/traffic-traces?ns=tt-1
```

The `ns` query stands for `namespace`. When viewing a single item, the view changes slightly and provides a "View All" button to go back to the full list of items from that mesh - [screenshot](https://share.getcloudapp.com/E0uzzzZN)