### PR TITLE
v0.5.1 Fixes

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=false
+VUE_APP_MOCK_API_ENABLED=true
 VUE_APP_KUMA_CONFIG=/dev-api-config.json

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=true
+VUE_APP_MOCK_API_ENABLED=false
 VUE_APP_KUMA_CONFIG=/dev-api-config.json

--- a/src/App.vue
+++ b/src/App.vue
@@ -93,8 +93,11 @@ export default {
             // fetch all dataplanes
             // this.$store.dispatch('getAllDataplanes')
 
-            // fetch the version
+            // fetch the version and store it in localStorage
             this.$store.dispatch('getVersion')
+              .then(() => {
+                localStorage.setItem('kumaVersion', this.$store.getters.getVersion)
+              })
 
             // fetch the tagline
             this.$store.dispatch('getTagline')

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,13 +90,22 @@ export default {
             // fetch the mesh list
             this.$store.dispatch('fetchMeshList')
 
-            // fetch all dataplanes
-            // this.$store.dispatch('getAllDataplanes')
-
             // fetch the version and store it in localStorage
             this.$store.dispatch('getVersion')
               .then(() => {
-                localStorage.setItem('kumaVersion', this.$store.getters.getVersion)
+                const newVersion = this.$store.getters.getVersion
+                const lsVersion = localStorage.getItem('kumaVersion') || null
+
+                // if the version stored in the browser is different than the
+                // version running, update the version in localStorage, and
+                // reload the page
+                if (lsVersion !== newVersion) {
+                  // reload the app
+                  this.$router.go()
+
+                  // update the version in localStorage
+                  localStorage.setItem('kumaVersion', newVersion)
+                }
               })
 
             // fetch the tagline

--- a/src/assets/styles/components.css
+++ b/src/assets/styles/components.css
@@ -51,6 +51,12 @@
   padding: 2rem 0;
 }
 
+/* KTabs overrides */
+
+.k-tabs .tab-container {
+  outline: 0 !important;
+}
+
 /* misc utils */
 
 .help-icon {

--- a/src/components/Utils/OnboardingCheck.vue
+++ b/src/components/Utils/OnboardingCheck.vue
@@ -95,11 +95,24 @@ export default {
 }
 
 .alert-content {
-  display: flex;
-  align-items: center;
 
-  > *:first-of-type {
-    margin-right: var(--spacing-md);
+  @media screen and (min-width: 700px) {
+    display: flex;
+    align-items: center;
+
+    > *:first-of-type {
+      margin-right: var(--spacing-md);
+    }
+
+    > *:last-of-type {
+      min-width: 150px;
+    }
+  }
+
+  @media screen and (max-width: 699px) {
+    > *:last-of-type {
+      margin-top: 10px;
+    }
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -68,7 +68,10 @@ function SETUP_VUE_APP () {
     .then(response => {
       const apiUrl = response.data.apiUrl
       const kumaEnv = response.data.environment
-      const storedKumaEnv = localStorage.getItem('kumaEnv') !== null ? localStorage.getItem('kumaEnv').toString() : null
+
+      const storedKumaEnv = localStorage.getItem('kumaEnv') !== null
+        ? localStorage.getItem('kumaEnv').toString()
+        : null
 
       /**
        * Always check the API URL and set it accordingly for the app to access.

--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,7 @@ export default (store) => {
         title: 'Page not found',
         excludeAsBreadcrumb: true
       },
-      component: () => import('@/views/NotFound')
+      component: () => import(/* webpackChunkName: "not-found" */ '@/views/NotFound')
     },
     {
       path: '/',
@@ -37,7 +37,7 @@ export default (store) => {
             simpleContent: true,
             onboardingProcess: true
           },
-          component: () => import('@/views/Onboarding/GetStarted')
+          component: () => import(/* webpackChunkName: "onboarding-get-started" */ '@/views/Onboarding/GetStarted')
         },
         {
           path: 'complete',
@@ -51,7 +51,7 @@ export default (store) => {
             simpleContent: true,
             onboardingProcess: true
           },
-          component: () => import('@/views/Onboarding/Complete')
+          component: () => import(/* webpackChunkName: "onboarding-complete" */ '@/views/Onboarding/Complete')
         }
       ]
     },
@@ -59,7 +59,7 @@ export default (store) => {
       // Entity Wizard
       path: '/wizard',
       name: 'wizard',
-      component: () => import('@/views/Shell'),
+      component: () => import(/* webpackChunkName: "shell-default" */ '@/views/Shell'),
       children: [
         {
           path: 'mesh',
@@ -68,7 +68,7 @@ export default (store) => {
             title: 'Create a new Mesh',
             excludeAsBreadcrumb: true
           },
-          component: () => import('@/views/Wizard/views/Mesh')
+          component: () => import(/* webpackChunkName: "wizard-mesh" */ '@/views/Wizard/views/Mesh')
         },
         {
           path: 'kubernetes-dataplane',
@@ -77,7 +77,7 @@ export default (store) => {
             title: 'Create a new Kubernetes Dataplane',
             excludeAsBreadcrumb: true
           },
-          component: () => import('@/views/Wizard/views/DataplaneKubernetes')
+          component: () => import(/* webpackChunkName: "wizard-dataplane-kubernetes" */ '@/views/Wizard/views/DataplaneKubernetes')
         },
         {
           path: 'universal-dataplane',
@@ -86,7 +86,7 @@ export default (store) => {
             title: 'Create a new Universal Dataplane',
             excludeAsBreadcrumb: true
           },
-          component: () => import('@/views/Wizard/views/DataplaneUniversal')
+          component: () => import(/* webpackChunkName: "wizard-dataplane-universal" */ '@/views/Wizard/views/DataplaneUniversal')
         }
       ]
     },
@@ -97,7 +97,7 @@ export default (store) => {
       path: '/overview',
       alias: '/',
       name: 'global-overview',
-      component: () => import('@/views/Overview'),
+      component: () => import(/* webpackChunkName: "global-overview" */ '@/views/Overview'),
       meta: {
         title: 'Global Overview',
         breadcrumb: 'Overview'
@@ -113,7 +113,7 @@ export default (store) => {
         parent: 'global-overview'
       },
       params: { mesh: ':mesh' },
-      component: () => import('@/views/Shell'),
+      component: () => import(/* webpackChunkName: "shell-default" */ '@/views/Shell'),
       children: [
         {
           path: ':mesh',
@@ -123,7 +123,7 @@ export default (store) => {
             parent: 'all-meshes'
           },
           params: { mesh: ':mesh' },
-          component: () => import('@/views/Entities/Meshes')
+          component: () => import(/* webpackChunkName: "meshes" */ '@/views/Entities/Meshes')
         }
       ]
     },
@@ -136,7 +136,7 @@ export default (store) => {
         parent: 'all-meshes'
       },
       params: { mesh: ':mesh' },
-      component: () => import('@/views/Shell'),
+      component: () => import(/* webpackChunkName: "shell-default" */ '@/views/Shell'),
       children: [
         // dataplanes
         {
@@ -146,7 +146,7 @@ export default (store) => {
             title: 'Dataplanes',
             parent: 'dataplanes'
           },
-          component: () => import('@/views/Entities/Dataplanes')
+          component: () => import(/* webpackChunkName: "dataplanes" */ '@/views/Entities/Dataplanes')
         },
         // traffic permissions
         {
@@ -155,7 +155,7 @@ export default (store) => {
           meta: {
             title: 'Traffic Permissions'
           },
-          component: () => import('@/views/Policies/TrafficPermissions')
+          component: () => import(/* webpackChunkName: "traffic-permissions" */ '@/views/Policies/TrafficPermissions')
         },
         // traffic routes
         {
@@ -164,7 +164,7 @@ export default (store) => {
           meta: {
             title: 'Traffic Routes'
           },
-          component: () => import('@/views/Policies/TrafficRoutes')
+          component: () => import(/* webpackChunkName: "traffic-routes" */ '@/views/Policies/TrafficRoutes')
         },
         // traffic logs
         {
@@ -173,7 +173,7 @@ export default (store) => {
           meta: {
             title: 'Traffic Logs'
           },
-          component: () => import('@/views/Policies/TrafficLogs')
+          component: () => import(/* webpackChunkName: "traffic-logs" */ '@/views/Policies/TrafficLogs')
         },
         // traffic traces
         {
@@ -182,7 +182,7 @@ export default (store) => {
           meta: {
             title: 'Traffic Traces'
           },
-          component: () => import('@/views/Policies/TrafficTraces')
+          component: () => import(/* webpackChunkName: "traffic-traces" */ '@/views/Policies/TrafficTraces')
         },
         // fault injections
         {
@@ -191,7 +191,7 @@ export default (store) => {
           meta: {
             title: 'Fault Injections'
           },
-          component: () => import('@/views/Policies/FaultInjections')
+          component: () => import(/* webpackChunkName: "fault-injections" */ '@/views/Policies/FaultInjections')
         },
         // circuit breakers
         {
@@ -200,7 +200,7 @@ export default (store) => {
           meta: {
             title: 'Circuit Breakers'
           },
-          component: () => import('@/views/Policies/CircuitBreakers')
+          component: () => import(/* webpackChunkName: "circuit-breakers" */ '@/views/Policies/CircuitBreakers')
         },
         // health checks
         {
@@ -209,7 +209,7 @@ export default (store) => {
           meta: {
             title: 'Health Checks'
           },
-          component: () => import('@/views/Policies/HealthChecks')
+          component: () => import(/* webpackChunkName: "health-checks" */ '@/views/Policies/HealthChecks')
         },
         // proxy templates
         {
@@ -218,7 +218,7 @@ export default (store) => {
           meta: {
             title: 'Proxy Templates'
           },
-          component: () => import('@/views/Policies/ProxyTemplates')
+          component: () => import(/* webpackChunkName: "proxy-templates" */ '@/views/Policies/ProxyTemplates')
         }
       ]
     }

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -97,7 +97,7 @@ export default class Mock {
       //     }
       //   }
       // })
-      .onGet('/dataplanes').reply(200, {
+      .onGet('/meshes/default/dataplanes').reply(200, {
         total: 2,
         items: [
           {

--- a/src/views/Entities/Dataplanes.vue
+++ b/src/views/Entities/Dataplanes.vue
@@ -508,10 +508,22 @@ export default {
                   if (res.dataplaneInsight.mTLS) {
                     const mtls = res.dataplaneInsight.mTLS
 
+                    const rawExpDate = new Date(mtls.certificateExpirationTime)
+                    // this prevents any weird date shifting
+                    const fixedExpDate = new Date(
+                      rawExpDate.getTime() +
+                      rawExpDate.getTimezoneOffset() * 60000
+                    )
+                    // assembled to display date and time (in 24-hour format)
+                    const assembledExpDate = `
+                      ${fixedExpDate.toLocaleDateString('en-US')} ${fixedExpDate.getHours()}:${fixedExpDate.getMinutes()}:${fixedExpDate.getSeconds()}
+                    `
+
                     data = {
                       certificateExpirationTime: {
                         label: 'Expiration Time',
-                        value: humanReadableDate(mtls.certificateExpirationTime)
+                        // value: new Date(mtls.certificateExpirationTime).toLocaleDateString('en-US')
+                        value: assembledExpDate
                       },
                       lastCertificateRegeneration: {
                         label: 'Last Generated',

--- a/src/views/Wizard/components/StepSkeleton.vue
+++ b/src/views/Wizard/components/StepSkeleton.vue
@@ -134,6 +134,13 @@ export default {
     this.resetProcess()
     // this sets the starting step upon load
     this.setStartingStep()
+    // add a body class so we can target styling elements outside of the
+    // Wizard components accordingly so that they don't clash with the
+    // Wizard sidebar
+    document.body.classList.add('wizard-page')
+  },
+  destroyed () {
+    document.body.classList.remove('wizard-page')
   },
   methods: {
     goToStep (index) {
@@ -224,6 +231,14 @@ export default {
     color: red;
     font-weight: bold;
     font-style: italic;
+  }
+}
+
+// forces items outside of the wizard content container to adhere
+// to the width limitations so that they don't underlap the Wizard sidebar
+@media screen and (min-width: 1220px) {
+  body.wizard-page .main-content > .page > *:not(.overview) {
+    max-width: calc(100% - 320px);
   }
 }
 </style>

--- a/src/views/Wizard/components/Switcher.vue
+++ b/src/views/Wizard/components/Switcher.vue
@@ -9,7 +9,7 @@
         v-if="environment === 'kubernetes' || environment === 'universal'"
         slot="title"
       >
-        Running on {{ environment }}
+        Running on <span class="env-name">{{ environment }}</span>
       </template>
       <template slot="message">
         <div v-if="environment === 'kubernetes'">
@@ -110,6 +110,8 @@ export default {
 }
 </script>
 
-<style>
-
+<style lang="scss" scoped>
+.env-name {
+  text-transform: capitalize;
+}
 </style>

--- a/src/views/Wizard/mixins/updateQuery.js
+++ b/src/views/Wizard/mixins/updateQuery.js
@@ -21,11 +21,11 @@ export default {
           query: {
             [query]: value
           }
-        })
+        }).catch(err => {})
       } else {
         router.push({
           query: Object.assign({}, route.query, { [query]: value })
-        })
+        }).catch(err => {})
       }
     }
   }

--- a/src/views/Wizard/views/DataplaneKubernetes.vue
+++ b/src/views/Wizard/views/DataplaneKubernetes.vue
@@ -621,7 +621,7 @@ import Tabs from '@/components/Utils/Tabs'
 import StepSkeleton from '@/views/Wizard/components/StepSkeleton'
 import Switcher from '@/views/Wizard/components/Switcher'
 import CodeView from '@/components/Skeletons/CodeView'
-import Scanner from '@/views/Wizard/components/Scanner'
+// import Scanner from '@/views/Wizard/components/Scanner'
 
 // schema for building code output
 // import meshSchema from '@/views/Wizard/schemas/Mesh'
@@ -639,8 +639,8 @@ export default {
     Tabs,
     StepSkeleton,
     Switcher,
-    CodeView,
-    Scanner
+    CodeView
+    // Scanner
   },
   mixins: [
     FormatForCLI,
@@ -680,7 +680,7 @@ export default {
       ],
       startScanner: false,
       scanFound: false,
-      // hideScannerSiblings: false,
+      hideScannerSiblings: false,
       scanError: false,
       isComplete: false,
       nextDisabled: true,
@@ -804,16 +804,6 @@ export default {
       // do nothing if there is no Mesh nor Dataplane found
       if (!mesh || !dataplane) return
 
-      /**
-       * TODO
-       * this will eventually change to `this.$api.getDataplaneFromMesh()`
-       * we will need to get the Mesh namespace the user selects, or the one
-       * they create, as well as the Dataplane namespace.
-       *
-       * This is also dependent upon multiple Kubernetes endpoints that don't
-       * yet exist in Kuma and need to be created.
-       *
-       */
       this.$api.getDataplaneFromMesh(mesh, dataplane)
         .then(response => {
           if (response && response.name.length > 0) {

--- a/vue.config.js
+++ b/vue.config.js
@@ -8,6 +8,9 @@ module.exports = {
     sourceMap: false
   },
   chainWebpack: config => {
+    config.output
+      .chunkFilename('[name].js?t=[chunkhash:8]')
+
     config.module
       .rule('ignore-some-things')
       .test(/\/(LICENSE|COPYRIGHT|CONTRIBUTORS|README)$|.*\.(txt|ijmap|md)|\/\..*/i)


### PR DESCRIPTION
This PR covers a list of fixes and improvements for the 0.5.1 release.

## Tasks

* **Fix:** K8s DP wizard: the "Next" control is no longer appearing when selecting a Mesh -- this was caused by missing variable that was commented out but not reintroduced in this single view.
* **Change:** disable the "selected" effect when clicking on a row overview -- in the KTabs component, the tab content has an outline around it when clicked on. This change hides the outline.
* **Fix:** the Expiration Time on the Certificate Insights tab needs to be displayed as a regular date/time, not a human-readable relative one -- in all other instances of time and date being displayed, it's human-readable and relative. For this instance it simply needed to be the date/time itself with no additional modification.
* **Fix / Improvement:** when there is a new version of Kuma, a force-refresh is required to make the GUI work, otherwise a blank screen is displayed. I was unable to reproduce this but have made multiple changes to try and address it:
-- I've made it so that the version is now stored in localStorage and the app checks the version from Kuma itself against the localStorage one. If they are different, the app updates the localStorage version string, and forces a reload on the page itself.
-- Additionally, I've changed the JS file chunk naming for every route in webpack's configuration. This means that instead of the compiled JS files always being randomized string names that are always completely different after every compile, they are named according to route. e.g. `12345678.js` would be renamed to something like `traffic-routes.js`.
-- In addition to the above, I have also added cache busting to the compiled JS files. So `traffic-routes.js` turns into `traffic-routes?t=1234abcd`. This helps ensure that each new version forces the browser to reload the JS files fresh.