### PR TITLE
mTLS warning on Traffic Permissions

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=true
+VUE_APP_MOCK_API_ENABLED=false
 VUE_APP_KUMA_CONFIG=/dev-api-config.json

--- a/src/components/Skeletons/YamlView.vue
+++ b/src/components/Skeletons/YamlView.vue
@@ -206,6 +206,7 @@ export default {
         delete sourceObj.type
         delete sourceObj.name
 
+        newObj.apiVersion = 'kuma.io/v1alpha1'
         newObj.kind = type
         newObj.metadata = {
           name: name

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -19,84 +19,103 @@ export default class Mock {
       'background: gray; color: white; display: block; padding: 0.25rem;')
 
     this.mock
-      // .onGet('/meshes').reply(200, {
-      //   total: 3,
-      //   items: [
-      //     {
-      //       mtls: {
-      //         ca: {
-      //           builtin: {}
-      //         }
-      //       },
-      //       name: 'default',
-      //       type: 'Mesh'
-      //     },
-      //     {
-      //       mtls: {
-      //         ca: {
-      //           builtin: {}
-      //         }
-      //       },
-      //       name: 'mesh-01',
-      //       type: 'Mesh'
-      //     },
-      //     {
-      //       mtls: {
-      //         ca: {
-      //           builtin: {}
-      //         }
-      //       },
-      //       name: 'kong-mania-12',
-      //       type: 'Mesh'
-      //     },
-      //     {
-      //       mtls: {
-      //         ca: {
-      //           builtin: {}
-      //         }
-      //       },
-      //       name: 'hello-world',
-      //       type: 'Mesh'
-      //     }
-      //   ],
-      //   next: null
-      // })
-      // .onGet('/meshes/default').reply(200, {
-      //   type: 'Mesh',
-      //   name: 'default',
-      //   mtls: {
-      //     ca: {
-      //       builtin: {}
-      //     }
-      //   }
-      // })
-      // .onGet('/meshes/mesh-01').reply(200, {
-      //   type: 'Mesh',
-      //   name: 'mesh-01',
-      //   mtls: {
-      //     ca: {
-      //       builtin: {}
-      //     }
-      //   }
-      // })
-      // .onGet('/meshes/kong-mania-12').reply(200, {
-      //   type: 'Mesh',
-      //   name: 'kong-mania-12',
-      //   mtls: {
-      //     ca: {
-      //       builtin: {}
-      //     }
-      //   }
-      // })
-      // .onGet('/meshes/hello-world').reply(200, {
-      //   type: 'Mesh',
-      //   name: 'hello-world',
-      //   mtls: {
-      //     ca: {
-      //       builtin: {}
-      //     }
-      //   }
-      // })
+      .onGet('/meshes').reply(200, {
+        total: 3,
+        items: [
+          {
+            name: 'default',
+            type: 'Mesh'
+          },
+          {
+            name: 'mesh-01',
+            type: 'Mesh',
+            mtls: {
+              enabledBackend: 'ca-1',
+              backends: [
+                {
+                  name: 'ca-1',
+                  type: 'provided',
+                  dpCert: {
+                    rotation: {
+                      expiration: '1d'
+                    }
+                  },
+                  conf: {
+                    cert: {
+                      secret: 'name-of-secret'
+                    },
+                    key: {
+                      secret: 'name-of-secret'
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            name: 'kong-mania-12',
+            type: 'Mesh'
+          },
+          {
+            name: 'hello-world',
+            type: 'Mesh'
+          }
+        ],
+        next: null
+      })
+      .onGet('/meshes/default').reply(200, {
+        type: 'Mesh',
+        name: 'default',
+        mtls: {
+          ca: {
+            builtin: {}
+          }
+        }
+      })
+      .onGet('/meshes/mesh-01').reply(200, {
+        type: 'Mesh',
+        name: 'mesh-01',
+        mtls: {
+          enabledBackend: 'ca-1',
+          backends: [
+            {
+              name: 'ca-1',
+              type: 'provided',
+              dpCert: {
+                rotation: {
+                  expiration: '1d'
+                }
+              },
+              conf: {
+                cert: {
+                  secret: 'name-of-secret'
+                },
+                key: {
+                  secret: 'name-of-secret'
+                }
+              }
+            }
+          ]
+        }
+      })
+      .onGet('/meshes/kong-mania-12').reply(200, {
+        type: 'Mesh',
+        name: 'kong-mania-12',
+        mtls: {
+          ca: {
+            builtin: {}
+          }
+        }
+      })
+      .onGet('/meshes/hello-world').reply(200, {
+        type: 'Mesh',
+        name: 'hello-world',
+        mtls: {
+          ca: {
+            builtin: {}
+          }
+        }
+      })
       .onGet('/meshes/default/dataplanes').reply(200, {
         total: 2,
         items: [
@@ -1560,12 +1579,12 @@ export default class Mock {
           }
         ]
       })
-      .onGet('/meshes/default/traffic-permissions').reply(200, {
+      .onGet('/meshes/mesh-01/traffic-permissions').reply(200, {
         total: 3,
         items: [
           {
             type: 'TrafficPermission',
-            mesh: 'default',
+            mesh: 'mesh-01',
             name: 'tp-1',
             sources: [
               {
@@ -1584,7 +1603,7 @@ export default class Mock {
           },
           {
             type: 'TrafficPermission',
-            mesh: 'default',
+            mesh: 'mesh-01',
             name: 'tp-1234',
             sources: [
               {
@@ -1603,7 +1622,7 @@ export default class Mock {
           },
           {
             type: 'TrafficPermission',
-            mesh: 'default',
+            mesh: 'mesh-01',
             name: 'tp-alpha-tango-donut',
             sources: [
               {
@@ -1622,7 +1641,7 @@ export default class Mock {
           }
         ]
       })
-      .onGet('/meshes/default/traffic-permissions/tp-1').reply(200, {
+      .onGet('/meshes/mesh-01/traffic-permissions/tp-1').reply(200, {
         type: 'TrafficPermission',
         mesh: 'mesh-1',
         name: 'tp-1',
@@ -1643,7 +1662,7 @@ export default class Mock {
           }
         ]
       })
-      .onGet('/meshes/default/traffic-permissions/tp-1234').reply(200, {
+      .onGet('/meshes/mesh-01/traffic-permissions/tp-1234').reply(200, {
         type: 'TrafficPermission',
         mesh: 'mesh-1',
         name: 'tp-1234',
@@ -1664,7 +1683,7 @@ export default class Mock {
           }
         ]
       })
-      .onGet('/meshes/default/traffic-permissions/tp-alpha-tango-donut').reply(200, {
+      .onGet('/meshes/mesh-01/traffic-permissions/tp-alpha-tango-donut').reply(200, {
         type: 'TrafficPermission',
         mesh: 'mesh-1',
         name: 'tp-alpha-tango-donut',

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -65,12 +65,29 @@ export default class Mock {
       })
       .onGet('/meshes/default').reply(200, {
         type: 'Mesh',
-        name: 'default',
-        mtls: {
-          ca: {
-            builtin: {}
-          }
-        }
+        name: 'default'
+        // mtls: {
+        //   enabledBackend: 'ca-1',
+        //   backends: [
+        //     {
+        //       name: 'ca-1',
+        //       type: 'provided',
+        //       dpCert: {
+        //         rotation: {
+        //           expiration: '1d'
+        //         }
+        //       },
+        //       conf: {
+        //         cert: {
+        //           secret: 'name-of-secret'
+        //         },
+        //         key: {
+        //           secret: 'name-of-secret'
+        //         }
+        //       }
+        //     }
+        //   ]
+        // }
       })
       .onGet('/meshes/mesh-01').reply(200, {
         type: 'Mesh',

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -1,5 +1,26 @@
 <template>
   <div class="traffic-permissions">
+    <div
+      v-if="securityWarning"
+      class="alert-wrapper"
+    >
+      <KAlert appearance="warning">
+        <template slot="alertMessage">
+          <div class="alert-content">
+            <p>
+              <strong>All traffic is allowed:</strong> All service traffic is
+              enabled on this Mesh by default because Mutual TLS is not enabled.
+            </p>
+            <p>
+              Traffic Permissions are currently being ignored by the
+              <strong>{{ $route.params.mesh }}</strong> Mesh because Mutual TLS
+              is not enabled. You can still create and edit Traffic Permissions,
+              but they will go into effect only when Mutual TLS is enabled on the Mesh.
+            </p>
+          </div>
+        </template>
+      </KAlert>
+    </div>
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -157,7 +178,8 @@ export default {
       pageOffset: null,
       next: null,
       hasNext: false,
-      previous: []
+      previous: [],
+      securityWarning: false
     }
   },
   computed: {
@@ -205,6 +227,7 @@ export default {
   methods: {
     init () {
       this.loadData()
+      this.mtlsWarning()
     },
     goToPreviousPage () {
       this.pageOffset = this.previous.pop()
@@ -352,10 +375,32 @@ export default {
           this.entityIsLoading = false
         }, process.env.VUE_APP_DATA_TIMEOUT)
       }
+    },
+    mtlsWarning () {
+      const mesh = this.$route.params.mesh
+      const entityMesh = (mesh !== 'all')
+        ? mesh
+        : null
+
+      if (entityMesh) {
+        return this.$api.getMesh(entityMesh)
+          .then(response => {
+            const { mtls } = response
+
+            if (mtls && mtls.enabledBackend && mtls.enabledBackend !== null) {
+              this.securityWarning = false
+            } else {
+              this.securityWarning = true
+            }
+          })
+      }
     }
   }
 }
 </script>
 
-<style>
+<style lang="scss" scoped>
+.alert-wrapper {
+  margin-bottom: var(--spacing-md);
+}
 </style>

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -10,8 +10,6 @@
             <p>
               <strong>All traffic is allowed:</strong> All service traffic is
               enabled on this Mesh by default because Mutual TLS is not enabled.
-            </p>
-            <p>
               Traffic Permissions are currently being ignored by the
               <strong>{{ $route.params.mesh }}</strong> Mesh because Mutual TLS
               is not enabled. You can still create and edit Traffic Permissions,


### PR DESCRIPTION
When viewing Traffic Permissions, there is now a warning when the selected Mesh does not have mTLS enabled. It checks that `mtls` is present in the Mesh entity, as well as if there is a selected backend in `enabledBackend`. If those conditions aren't met, the warning is displayed at the top of the Traffic Permissions page.

If the user is viewing information for all Meshes, this warning doesn't appear since it's specific to the Mesh itself.